### PR TITLE
Rework Gantt core: unified TimeScale coordinate system

### DIFF
--- a/__tests__/timeScale.test.ts
+++ b/__tests__/timeScale.test.ts
@@ -1,0 +1,140 @@
+import {
+  TimeScale,
+  buildTimeUnits,
+  shiftByUnits,
+  snapStart,
+  snapEnd,
+  addUnits,
+} from "../src/core";
+import { ViewMode } from "../src/types";
+
+describe("TimeScale", () => {
+  describe("header / bar consistency (drift fix)", () => {
+    // The whole point of the rework: bar edges must line up with the header
+    // columns regardless of month length. With the old linear-ms mapping a
+    // task starting on Feb 1 drifted a few pixels away from the Feb column.
+    test("a date on a column boundary lands exactly on the column edge", () => {
+      const start = new Date(2023, 0, 1); // Jan 1
+      const end = new Date(2023, 11, 31); // Dec 31
+      const unitWidth = 150;
+      const scale = new TimeScale(ViewMode.MONTH, start, end, unitWidth);
+
+      // 12 monthly columns, each 150px wide.
+      expect(scale.units.length).toBe(12);
+
+      // Each month-start must sit exactly on its column edge — no drift.
+      scale.units.forEach((unit, i) => {
+        expect(scale.dateToX(unit)).toBeCloseTo(i * unitWidth, 5);
+      });
+    });
+
+    test("today marker math agrees with bar positioning within a month", () => {
+      const start = new Date(2024, 0, 1);
+      const end = new Date(2024, 2, 31);
+      const unitWidth = 150;
+      const scale = new TimeScale(ViewMode.MONTH, start, end, unitWidth);
+
+      // Feb 2024 has 29 days; the 15th should be ~halfway across the column.
+      const feb15 = new Date(2024, 1, 15);
+      const x = scale.dateToX(feb15);
+      const febColumn = 1 * unitWidth;
+      const frac = (x - febColumn) / unitWidth;
+      expect(frac).toBeGreaterThan(0.4);
+      expect(frac).toBeLessThan(0.55);
+    });
+  });
+
+  describe("invertibility (stable drags)", () => {
+    test("xToDate is the inverse of dateToX across the timeline", () => {
+      const start = new Date(2023, 0, 1);
+      const end = new Date(2023, 5, 30);
+      const scale = new TimeScale(ViewMode.MONTH, start, end, 150);
+
+      for (let x = 0; x <= scale.totalWidth; x += 37) {
+        const date = scale.xToDate(x);
+        expect(scale.dateToX(date)).toBeCloseTo(x, 3);
+      }
+    });
+
+    test("day view round-trips dates exactly", () => {
+      const start = new Date(2023, 0, 1);
+      const end = new Date(2023, 0, 31);
+      const scale = new TimeScale(ViewMode.DAY, start, end, 50);
+
+      const d = new Date(2023, 0, 10, 0, 0, 0, 0);
+      const x = scale.dateToX(d);
+      const back = scale.xToDate(x);
+      expect(back.getDate()).toBe(10);
+    });
+  });
+
+  describe("clamping", () => {
+    test("dates outside the range clamp to the edges", () => {
+      const start = new Date(2023, 0, 1);
+      const end = new Date(2023, 1, 28);
+      const scale = new TimeScale(ViewMode.MONTH, start, end, 150);
+
+      expect(scale.dateToX(new Date(2022, 0, 1))).toBe(0);
+      expect(scale.dateToX(new Date(2030, 0, 1))).toBe(scale.totalWidth);
+    });
+  });
+
+  describe("currentUnitIndex", () => {
+    test("finds the column for a contained date and -1 otherwise", () => {
+      const start = new Date(2023, 0, 1);
+      const end = new Date(2023, 2, 31);
+      const scale = new TimeScale(ViewMode.MONTH, start, end, 150);
+
+      expect(scale.currentUnitIndex(new Date(2023, 1, 15))).toBe(1);
+      expect(scale.currentUnitIndex(new Date(2025, 0, 1))).toBe(-1);
+    });
+  });
+});
+
+describe("snapping and unit shifts", () => {
+  test("snapStart/snapEnd produce clean day boundaries in coarse views", () => {
+    const d = new Date(2023, 4, 17, 13, 45, 30, 123);
+    const s = snapStart(d, ViewMode.MONTH);
+    const e = snapEnd(d, ViewMode.MONTH);
+    expect(s.getHours()).toBe(0);
+    expect(s.getMinutes()).toBe(0);
+    expect(e.getHours()).toBe(23);
+    expect(e.getMinutes()).toBe(59);
+  });
+
+  test("shiftByUnits preserves duration for a move", () => {
+    const start = new Date(2023, 0, 10);
+    const end = new Date(2023, 0, 20);
+    const ns = shiftByUnits(start, ViewMode.MONTH, 5); // +5 days
+    const ne = shiftByUnits(end, ViewMode.MONTH, 5);
+    expect(ns.getDate()).toBe(15);
+    expect(ne.getDate()).toBe(25);
+    // Duration unchanged
+    expect(ne.getTime() - ns.getTime()).toBe(end.getTime() - start.getTime());
+  });
+
+  test("addUnits grows the timeline by whole units", () => {
+    const d = new Date(2023, 0, 1);
+    expect(addUnits(d, ViewMode.MONTH, 3).getMonth()).toBe(3);
+    expect(addUnits(d, ViewMode.DAY, 7).getDate()).toBe(8);
+  });
+});
+
+describe("buildTimeUnits", () => {
+  test("month view yields one column per month inclusive", () => {
+    const units = buildTimeUnits(
+      ViewMode.MONTH,
+      new Date(2023, 0, 1),
+      new Date(2023, 2, 1),
+    );
+    expect(units.length).toBe(3);
+    expect(units[0].getMonth()).toBe(0);
+    expect(units[2].getMonth()).toBe(2);
+  });
+
+  test("invalid dates yield an empty grid", () => {
+    expect(
+      buildTimeUnits(ViewMode.MONTH, new Date("nope"), new Date(2023, 0, 1)),
+    ).toEqual([]);
+  });
+});

--- a/demo/src/components/layout/Navbar.tsx
+++ b/demo/src/components/layout/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import ThemeToggle from "../common/ThemeToggle";
 import { useTheme } from "../../context/ThemeContext";
@@ -13,20 +13,11 @@ import { Sheet, SheetContent, SheetTrigger } from "../ui/sheet";
 const Navbar: React.FC = () => {
     const { darkMode } = useTheme();
     const [isSearchOpen, setIsSearchOpen] = useState(false);
-    const [packageVersion, setPackageVersion] = useState<string>("");
+    // Version of the library this demo is built from (injected from the
+    // branch's package.json by Vite), so the badge reflects the local/PR code
+    // rather than whatever is published on npm as "latest".
+    const packageVersion = __LIB_VERSION__;
     const location = useLocation();
-
-    useEffect(() => {
-        // Fetch latest version from NPM registry
-        fetch("https://registry.npmjs.org/react-modern-gantt/latest")
-            .then(response => response.json())
-            .then(data => {
-                setPackageVersion(data.version);
-            })
-            .catch(error => {
-                console.error("Failed to fetch package version:", error);
-            });
-    }, []);
 
     const isActive = (path: string) => {
         return location.pathname === path;

--- a/demo/src/vite-env.d.ts
+++ b/demo/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// Injected by Vite (see vite.config.ts) from the library's package.json.
+declare const __LIB_VERSION__: string;

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -2,11 +2,22 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { resolve } from "path";
+import { readFileSync } from "fs";
+
+// Use the library version from the branch's own package.json so the demo
+// always reflects the code it is actually building from (../src), rather than
+// whatever is published to npm as "latest".
+const libVersion = JSON.parse(
+    readFileSync(resolve(__dirname, "../package.json"), "utf-8"),
+).version;
 
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [react(), tailwindcss()],
     base: "./",
+    define: {
+        __LIB_VERSION__: JSON.stringify(libVersion),
+    },
     build: {
         sourcemap: true,
         outDir: "dist",

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,6 +2,17 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        // Dedicated tsconfig (no outDir/declaration, rootDir ".") plus
+        // isolatedModules so TypeScript 6 config deprecation diagnostics
+        // don't fail the test run.
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
+  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',

--- a/src/components/core/GanttChart.tsx
+++ b/src/components/core/GanttChart.tsx
@@ -3,6 +3,7 @@ import React, {
   useState,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useImperativeHandle,
   forwardRef,
 } from "react";
@@ -17,25 +18,24 @@ import {
   ExportFormat,
   DependencyLink,
 } from "@/types";
-import { getMonthsBetween, findEarliestDate, findLatestDate } from "@/utils";
+import { findEarliestDate, findLatestDate } from "@/utils";
 import { Timeline, TodayMarker, DependencyLinks } from "@/components/timeline";
 import { ViewModeSelector } from "@/components/ui";
 import { TaskRow, TaskList } from "@/components/task";
 import { ExportService } from "@/services/ExportService";
-import {
-  addDays,
-  addHours,
-  addMinutes,
-  addQuarters,
-  startOfQuarter,
-  addYears,
-  startOfYear,
-} from "date-fns";
 import { CollisionService } from "@/services/CollisionService";
+import {
+  TimeScale,
+  addUnits,
+  getExtensionAmount,
+  defaultUnitWidth,
+} from "@/core";
 
 /**
- * GanttChart Component with ViewMode support and Export functionality
- * A modern, customizable Gantt chart for project timelines
+ * GanttChart — a modern, customizable Gantt chart for project timelines.
+ *
+ * A single {@link TimeScale} drives the header, the task bars, the today marker
+ * and dependency arrows, so everything stays pixel-consistent across view modes.
  */
 const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
   (
@@ -47,22 +47,22 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       currentDate = new Date(),
       showCurrentDateMarker = true,
       todayLabel = "Today",
-      editMode = true, // Global master switch - default true
-      allowProgressEdit = true, // Default true
-      allowTaskResize = true, // Default true
-      allowTaskMove = true, // Default true
+      editMode = true,
+      allowProgressEdit = true,
+      allowTaskResize = true,
+      allowTaskMove = true,
       headerLabel = "Resources",
       showProgress = false,
       darkMode = false,
       locale = "default",
       styles = {},
       viewMode = ViewMode.MONTH,
-      viewModes, // Array of allowed view modes or false to hide
-      showTimelineHeader = true, // Show hierarchical header (month/year)
+      viewModes,
+      showTimelineHeader = true,
       smoothDragging = true,
       movementThreshold = 3,
       animationSpeed = 0.25,
-      minuteStep = 5, // Default to 5-minute intervals
+      minuteStep = 5,
       infiniteScroll = false,
       onTimelineExtend,
       focusMode = true,
@@ -98,27 +98,44 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
     const [activeViewMode, setActiveViewMode] = useState<ViewMode>(viewMode);
     const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
-    const [viewUnitWidth, setViewUnitWidth] = useState<number>(150);
+    const [viewUnitWidth, setViewUnitWidth] = useState<number>(
+      defaultUnitWidth(viewMode),
+    );
     const [isAutoScrolling, setIsAutoScrolling] = useState<boolean>(false);
-
-    // Add a forceRender counter to trigger re-renders when tasks update
-    const [forceRender, setForceRender] = useState<number>(0);
 
     // Calculate timeline bounds
     const derivedStartDate = customStartDate || findEarliestDate(tasks);
     const derivedEndDate = customEndDate || findLatestDate(tasks);
 
+    // The single coordinate system shared by every sub-component.
+    const scale = useMemo(
+      () =>
+        new TimeScale(
+          activeViewMode,
+          derivedStartDate,
+          derivedEndDate,
+          viewUnitWidth,
+          minuteStep,
+        ),
+      [
+        activeViewMode,
+        derivedStartDate.getTime(),
+        derivedEndDate.getTime(),
+        viewUnitWidth,
+        minuteStep,
+      ],
+    );
+
+    const timeUnits = scale.units;
+    const totalUnits = timeUnits.length;
+    const currentUnitIndex = scale.currentUnitIndex(new Date());
+
     // --- Infinite scroll bookkeeping ---
-    // Guards against firing extension repeatedly while a re-render is pending.
     const isExtendingRef = useRef<boolean>(false);
-    // When extending to the left we must preserve the viewport position, since
-    // every task's pixel offset shifts as the start date moves earlier.
     const pendingLeftExtendRef = useRef<{
       prevScrollWidth: number;
       prevScrollLeft: number;
     } | null>(null);
-    // Always-current values so the scroll listener can stay subscribed without
-    // re-binding on every render.
     const extendStateRef = useRef({
       startDate: derivedStartDate,
       endDate: derivedEndDate,
@@ -130,16 +147,13 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       viewMode: activeViewMode,
     };
 
-    // Expose export methods via ref
+    // Expose export / scroll methods via ref
     useImperativeHandle(
       ref,
       () => ({
         exportChart: async (options?: ExportOptions): Promise<ExportResult> => {
           if (!containerRef.current) {
-            return {
-              success: false,
-              error: "Container element not available",
-            };
+            return { success: false, error: "Container element not available" };
           }
           return ExportService.export(containerRef.current, {
             ...options,
@@ -187,97 +201,23 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
           });
         },
 
-        getContainerElement: (): HTMLDivElement | null => {
-          return containerRef.current;
-        },
+        getContainerElement: (): HTMLDivElement | null => containerRef.current,
 
         scrollToDate: (date: Date): void => {
           if (!scrollContainerRef.current) return;
-
-          const timeUnitsArray = getTimeUnitsForMode(activeViewMode);
-          const targetIndex = findDateIndex(
-            date,
-            timeUnitsArray,
-            activeViewMode,
-          );
-
-          if (targetIndex >= 0) {
-            const scrollPosition = targetIndex * viewUnitWidth;
-            scrollContainerRef.current.scrollLeft =
-              scrollPosition - scrollContainerRef.current.clientWidth / 2;
-          }
+          const x = scale.dateToX(date);
+          scrollContainerRef.current.scrollLeft =
+            x - scrollContainerRef.current.clientWidth / 2;
         },
 
         scrollToToday: (): void => {
           scrollToNow(activeViewMode, viewUnitWidth);
         },
       }),
-      [darkMode, activeViewMode, viewUnitWidth],
+      [darkMode, scale, activeViewMode, viewUnitWidth],
     );
 
-    // Helper to find date index in time units
-    const findDateIndex = (
-      date: Date,
-      timeUnits: Date[],
-      mode: ViewMode,
-    ): number => {
-      switch (mode) {
-        case ViewMode.MINUTE:
-          return timeUnits.findIndex(
-            (d) =>
-              d.getHours() === date.getHours() &&
-              Math.floor(d.getMinutes() / (minuteStep || 5)) ===
-                Math.floor(date.getMinutes() / (minuteStep || 5)) &&
-              d.getDate() === date.getDate() &&
-              d.getMonth() === date.getMonth() &&
-              d.getFullYear() === date.getFullYear(),
-          );
-        case ViewMode.HOUR:
-          return timeUnits.findIndex(
-            (d) =>
-              d.getHours() === date.getHours() &&
-              d.getDate() === date.getDate() &&
-              d.getMonth() === date.getMonth() &&
-              d.getFullYear() === date.getFullYear(),
-          );
-        case ViewMode.DAY:
-          return timeUnits.findIndex(
-            (d) =>
-              d.getDate() === date.getDate() &&
-              d.getMonth() === date.getMonth() &&
-              d.getFullYear() === date.getFullYear(),
-          );
-        case ViewMode.WEEK:
-          return timeUnits.findIndex((d) => {
-            const weekEndDate = new Date(d);
-            weekEndDate.setDate(d.getDate() + 6);
-            return date >= d && date <= weekEndDate;
-          });
-        case ViewMode.MONTH:
-          return timeUnits.findIndex(
-            (d) =>
-              d.getMonth() === date.getMonth() &&
-              d.getFullYear() === date.getFullYear(),
-          );
-        case ViewMode.QUARTER:
-          const dateQuarter = Math.floor(date.getMonth() / 3);
-          return timeUnits.findIndex(
-            (d) =>
-              Math.floor(d.getMonth() / 3) === dateQuarter &&
-              d.getFullYear() === date.getFullYear(),
-          );
-        case ViewMode.YEAR:
-          return timeUnits.findIndex(
-            (d) => d.getFullYear() === date.getFullYear(),
-          );
-        default:
-          return -1;
-      }
-    };
-
-    // NEW: Infinite scroll - extend timeline when needed.
-    // Reads the latest bounds/mode from a ref so it works both from the drag
-    // auto-scroll (TaskRow) and the proactive scroll listener below.
+    // Infinite scroll: extend the timeline by a chunk of units in a direction.
     const handleTimelineExtension = (direction: "left" | "right") => {
       if (!infiniteScroll || !onTimelineExtend) return;
 
@@ -287,306 +227,23 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         viewMode: curMode,
       } = extendStateRef.current;
 
-      const extensionAmount = getExtensionAmount(curMode);
-      let newStartDate = curStart;
-      let newEndDate = curEnd;
-
-      if (direction === "left") {
-        newStartDate = subtractTimeUnits(curStart, extensionAmount, curMode);
-      } else {
-        newEndDate = addTimeUnits(curEnd, extensionAmount, curMode);
-      }
+      const amount = getExtensionAmount(curMode);
+      const newStartDate =
+        direction === "left"
+          ? addUnits(curStart, curMode, -amount, minuteStep)
+          : curStart;
+      const newEndDate =
+        direction === "right"
+          ? addUnits(curEnd, curMode, amount, minuteStep)
+          : curEnd;
 
       onTimelineExtend(direction, newStartDate, newEndDate);
     };
 
-    // Helper to get extension amount based on view mode
-    const getExtensionAmount = (mode: ViewMode): number => {
-      switch (mode) {
-        case ViewMode.MINUTE:
-          return 60; // Add 1 hour
-        case ViewMode.HOUR:
-          return 24; // Add 1 day
-        case ViewMode.DAY:
-          return 7; // Add 1 week
-        case ViewMode.WEEK:
-          return 4; // Add 1 month
-        case ViewMode.MONTH:
-          return 3; // Add 3 months
-        case ViewMode.QUARTER:
-          return 4; // Add 1 year
-        case ViewMode.YEAR:
-          return 5; // Add 5 years
-        default:
-          return 3;
-      }
-    };
-
-    // Helper to add time units
-    const addTimeUnits = (date: Date, amount: number, mode: ViewMode): Date => {
-      switch (mode) {
-        case ViewMode.MINUTE:
-          return addMinutes(date, amount);
-        case ViewMode.HOUR:
-          return addHours(date, amount);
-        case ViewMode.DAY:
-          return addDays(date, amount);
-        case ViewMode.WEEK:
-          return addDays(date, amount * 7);
-        case ViewMode.MONTH:
-          return new Date(
-            date.getFullYear(),
-            date.getMonth() + amount,
-            date.getDate(),
-          );
-        case ViewMode.QUARTER:
-          return addQuarters(date, amount);
-        case ViewMode.YEAR:
-          return addYears(date, amount);
-        default:
-          return date;
-      }
-    };
-
-    // Helper to subtract time units
-    const subtractTimeUnits = (
-      date: Date,
-      amount: number,
-      mode: ViewMode,
-    ): Date => {
-      switch (mode) {
-        case ViewMode.MINUTE:
-          return addMinutes(date, -amount);
-        case ViewMode.HOUR:
-          return addHours(date, -amount);
-        case ViewMode.DAY:
-          return addDays(date, -amount);
-        case ViewMode.WEEK:
-          return addDays(date, -amount * 7);
-        case ViewMode.MONTH:
-          return new Date(
-            date.getFullYear(),
-            date.getMonth() - amount,
-            date.getDate(),
-          );
-        case ViewMode.QUARTER:
-          return addQuarters(date, -amount);
-        case ViewMode.YEAR:
-          return addYears(date, -amount);
-        default:
-          return date;
-      }
-    };
-
-    // Time unit calculation functions
-    const getTimeUnits = () => {
-      switch (activeViewMode) {
-        case ViewMode.MINUTE:
-          return getMinutesBetween(
-            derivedStartDate,
-            derivedEndDate,
-            minuteStep,
-          );
-        case ViewMode.HOUR:
-          return getHoursBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.DAY:
-          return getDaysBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.WEEK:
-          return getWeeksBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.MONTH:
-          return getMonthsBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.QUARTER:
-          return getQuartersBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.YEAR:
-          return getYearsBetween(derivedStartDate, derivedEndDate);
-        default:
-          return getMonthsBetween(derivedStartDate, derivedEndDate);
-      }
-    };
-
-    // Get minutes between dates with configurable step - OPTIMIZED for performance
-    const getMinutesBetween = (
-      start: Date,
-      end: Date,
-      step: number = 5,
-    ): Date[] => {
-      const minutes: Date[] = [];
-      let currentDate = new Date(start);
-      currentDate.setSeconds(0, 0);
-
-      // Round to nearest minute step
-      const currentMinutes = currentDate.getMinutes();
-      const roundedMinutes = Math.floor(currentMinutes / step) * step;
-      currentDate.setMinutes(roundedMinutes);
-
-      const endDateAdjusted = new Date(end);
-      endDateAdjusted.setMinutes(endDateAdjusted.getMinutes(), 59, 999);
-
-      // PERFORMANCE: Limit minute view to max 500 intervals to prevent lag
-      const maxIntervals = 500;
-      let intervalCount = 0;
-
-      while (currentDate <= endDateAdjusted && intervalCount < maxIntervals) {
-        minutes.push(new Date(currentDate));
-        currentDate = addMinutes(currentDate, step);
-        intervalCount++;
-      }
-
-      // If we hit the limit, warn and show reduced view
-      if (intervalCount >= maxIntervals) {
-        console.warn(
-          `Minute view limited to ${maxIntervals} intervals for performance. ` +
-            `Consider using a larger time range or switching to Hour view.`,
-        );
-      }
-
-      return minutes;
-    };
-
-    // Get hours between dates
-    const getHoursBetween = (start: Date, end: Date): Date[] => {
-      const hours: Date[] = [];
-      let currentDate = new Date(start);
-      currentDate.setMinutes(0, 0, 0);
-
-      const endDateAdjusted = new Date(end);
-      endDateAdjusted.setHours(endDateAdjusted.getHours(), 59, 59, 999);
-
-      while (currentDate <= endDateAdjusted) {
-        hours.push(new Date(currentDate));
-        currentDate = addHours(currentDate, 1);
-      }
-
-      return hours;
-    };
-
-    // Get days between dates
-    const getDaysBetween = (start: Date, end: Date): Date[] => {
-      const days: Date[] = [];
-      let currentDate = new Date(start);
-      currentDate.setHours(0, 0, 0, 0);
-
-      const endDateAdjusted = new Date(end);
-      endDateAdjusted.setHours(23, 59, 59, 999);
-
-      while (currentDate <= endDateAdjusted) {
-        days.push(new Date(currentDate));
-        currentDate = addDays(currentDate, 1);
-      }
-
-      return days;
-    };
-
-    // Get weeks between dates
-    const getWeeksBetween = (start: Date, end: Date): Date[] => {
-      const weeks: Date[] = [];
-      let currentDate = new Date(start);
-
-      while (currentDate <= end) {
-        weeks.push(new Date(currentDate));
-        currentDate = addDays(currentDate, 7);
-      }
-
-      return weeks;
-    };
-
-    // Get quarters between dates
-    const getQuartersBetween = (start: Date, end: Date): Date[] => {
-      const quarters: Date[] = [];
-      let currentDate = startOfQuarter(new Date(start));
-
-      while (currentDate <= end) {
-        quarters.push(new Date(currentDate));
-        currentDate = addQuarters(currentDate, 1);
-      }
-
-      return quarters;
-    };
-
-    // Get years between dates
-    const getYearsBetween = (start: Date, end: Date): Date[] => {
-      const years: Date[] = [];
-      let currentDate = startOfYear(new Date(start));
-
-      while (currentDate <= end) {
-        years.push(new Date(currentDate));
-        currentDate = addYears(currentDate, 1);
-      }
-
-      return years;
-    };
-
-    // Find current unit index for highlighting
-    const getCurrentUnitIndex = (): number => {
-      const today = new Date();
-
-      switch (activeViewMode) {
-        case ViewMode.MINUTE:
-          return timeUnits.findIndex(
-            (date) =>
-              date.getHours() === today.getHours() &&
-              Math.floor(date.getMinutes() / (minuteStep || 5)) ===
-                Math.floor(today.getMinutes() / (minuteStep || 5)) &&
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-        case ViewMode.HOUR:
-          return timeUnits.findIndex(
-            (date) =>
-              date.getHours() === today.getHours() &&
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-        case ViewMode.DAY:
-          return timeUnits.findIndex(
-            (date) =>
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-        case ViewMode.WEEK:
-          return timeUnits.findIndex((date) => {
-            const weekEndDate = new Date(date);
-            weekEndDate.setDate(date.getDate() + 6);
-            return today >= date && today <= weekEndDate;
-          });
-        case ViewMode.MONTH:
-          return timeUnits.findIndex(
-            (date) =>
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-        case ViewMode.QUARTER:
-          const todayQuarter = Math.floor(today.getMonth() / 3);
-          return timeUnits.findIndex(
-            (date) =>
-              Math.floor(date.getMonth() / 3) === todayQuarter &&
-              date.getFullYear() === today.getFullYear(),
-          );
-        case ViewMode.YEAR:
-          return timeUnits.findIndex(
-            (date) => date.getFullYear() === today.getFullYear(),
-          );
-        default:
-          return -1;
-      }
-    };
-
     // Get available view modes based on props
     const getAvailableViewModes = (): ViewMode[] | false => {
-      // If viewModes is explicitly set to false, return false to hide selector
-      if (viewModes === false) {
-        return false;
-      }
-
-      // If viewModes is provided as an array, use it
-      if (Array.isArray(viewModes)) {
-        return viewModes;
-      }
-
-      // Default standard view modes
+      if (viewModes === false) return false;
+      if (Array.isArray(viewModes)) return viewModes;
       return [
         ViewMode.DAY,
         ViewMode.WEEK,
@@ -596,323 +253,112 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       ];
     };
 
-    // Get time units and calculate current unit index
-    const timeUnits = getTimeUnits();
-    const totalUnits = timeUnits.length;
-    const currentUnitIndex = getCurrentUnitIndex();
-
     // Handle auto-scrolling state
     const handleAutoScrollingChange = (isScrolling: boolean) => {
       setIsAutoScrolling(isScrolling);
       if (scrollContainerRef.current) {
-        if (isScrolling) {
-          scrollContainerRef.current.classList.add("rmg-auto-scrolling");
-        } else {
-          scrollContainerRef.current.classList.remove("rmg-auto-scrolling");
-        }
+        scrollContainerRef.current.classList.toggle(
+          "rmg-auto-scrolling",
+          isScrolling,
+        );
       }
     };
 
     // Task interaction handlers
     const handleTaskUpdate = (groupId: string, updatedTask: Task) => {
-      if (onTaskUpdate) {
-        try {
-          const ensuredTask = {
-            ...updatedTask,
-            startDate:
-              updatedTask.startDate instanceof Date
-                ? updatedTask.startDate
-                : new Date(updatedTask.startDate),
-            endDate:
-              updatedTask.endDate instanceof Date
-                ? updatedTask.endDate
-                : new Date(updatedTask.endDate),
-          };
-
-          // Force a re-render to update collision detection
-          setForceRender((prev) => prev + 1);
-
-          onTaskUpdate(groupId, ensuredTask);
-        } catch (error) {
-          console.error("Error in handleTaskUpdate:", error);
-        }
+      if (!onTaskUpdate) return;
+      try {
+        const ensuredTask = {
+          ...updatedTask,
+          startDate:
+            updatedTask.startDate instanceof Date
+              ? updatedTask.startDate
+              : new Date(updatedTask.startDate),
+          endDate:
+            updatedTask.endDate instanceof Date
+              ? updatedTask.endDate
+              : new Date(updatedTask.endDate),
+        };
+        onTaskUpdate(groupId, ensuredTask);
+      } catch (error) {
+        console.error("Error in handleTaskUpdate:", error);
       }
     };
 
     const handleTaskClick = (task: Task, group: TaskGroup) => {
-      if (onTaskClick) {
-        try {
-          onTaskClick(task, group);
-        } catch (error) {
-          console.error("Error in handleTaskClick:", error);
-        }
+      try {
+        onTaskClick?.(task, group);
+      } catch (error) {
+        console.error("Error in handleTaskClick:", error);
       }
     };
 
     const handleTaskSelect = (task: Task, isSelected: boolean) => {
-      setSelectedTaskIds((prev) => {
-        if (isSelected) {
-          return [...prev, task.id];
-        } else {
-          return prev.filter((id) => id !== task.id);
-        }
-      });
-
-      if (onTaskSelect) {
-        try {
-          onTaskSelect(task, isSelected);
-        } catch (error) {
-          console.error("Error in onTaskSelect handler:", error);
-        }
+      setSelectedTaskIds((prev) =>
+        isSelected ? [...prev, task.id] : prev.filter((id) => id !== task.id),
+      );
+      try {
+        onTaskSelect?.(task, isSelected);
+      } catch (error) {
+        console.error("Error in onTaskSelect handler:", error);
       }
     };
 
-    // Calculate scroll position to center "now" in view
-    const calculateScrollToNow = (
-      mode: ViewMode,
-      unitWidth: number,
-      timeUnitsArray: Date[],
-    ): number => {
-      if (!scrollContainerRef.current || timeUnitsArray.length === 0) return 0;
-
-      const container = scrollContainerRef.current;
-      const today = new Date();
-
-      // Find the current unit index directly from timeUnits
-      let currentIndex = -1;
-      switch (mode) {
-        case ViewMode.MINUTE:
-          currentIndex = timeUnitsArray.findIndex(
-            (date) =>
-              date.getHours() === today.getHours() &&
-              Math.floor(date.getMinutes() / (minuteStep || 5)) ===
-                Math.floor(today.getMinutes() / (minuteStep || 5)) &&
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-          break;
-        case ViewMode.HOUR:
-          currentIndex = timeUnitsArray.findIndex(
-            (date) =>
-              date.getHours() === today.getHours() &&
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-          break;
-        case ViewMode.DAY:
-          currentIndex = timeUnitsArray.findIndex(
-            (date) =>
-              date.getDate() === today.getDate() &&
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-          break;
-        case ViewMode.WEEK:
-          currentIndex = timeUnitsArray.findIndex((date) => {
-            const weekEndDate = new Date(date);
-            weekEndDate.setDate(date.getDate() + 6);
-            return today >= date && today <= weekEndDate;
-          });
-          break;
-        case ViewMode.MONTH:
-          currentIndex = timeUnitsArray.findIndex(
-            (date) =>
-              date.getMonth() === today.getMonth() &&
-              date.getFullYear() === today.getFullYear(),
-          );
-          break;
-        case ViewMode.QUARTER:
-          const todayQuarter = Math.floor(today.getMonth() / 3);
-          currentIndex = timeUnitsArray.findIndex(
-            (date) =>
-              Math.floor(date.getMonth() / 3) === todayQuarter &&
-              date.getFullYear() === today.getFullYear(),
-          );
-          break;
-        case ViewMode.YEAR:
-          currentIndex = timeUnitsArray.findIndex(
-            (date) => date.getFullYear() === today.getFullYear(),
-          );
-          break;
-      }
-
-      if (currentIndex < 0) return 0;
-
-      // Calculate the position of "now" marker
-      let nowPosition = 0;
-
-      switch (mode) {
-        case ViewMode.MINUTE: {
-          const minuteOfHour = today.getMinutes();
-          const secondOfMinute = today.getSeconds();
-          const minutePosition = (minuteOfHour + secondOfMinute / 60) / 60;
-          nowPosition = currentIndex * unitWidth + unitWidth * minutePosition;
-          break;
-        }
-        case ViewMode.HOUR: {
-          const minuteOfCurrentHour = today.getMinutes();
-          const hourPosition = minuteOfCurrentHour / 60;
-          nowPosition = currentIndex * unitWidth + unitWidth * hourPosition;
-          break;
-        }
-        case ViewMode.DAY:
-          nowPosition = currentIndex * unitWidth + unitWidth / 2;
-          break;
-        case ViewMode.WEEK: {
-          const dayOfWeek = today.getDay();
-          const normalizedDayOfWeek = (dayOfWeek + 7) % 7;
-          const dayPosition = normalizedDayOfWeek / 6;
-          nowPosition = currentIndex * unitWidth + unitWidth * dayPosition;
-          break;
-        }
-        case ViewMode.MONTH: {
-          const daysInMonth = new Date(
-            today.getFullYear(),
-            today.getMonth() + 1,
-            0,
-          ).getDate();
-          const dayPercentage = (today.getDate() - 1) / daysInMonth;
-          nowPosition = currentIndex * unitWidth + unitWidth * dayPercentage;
-          break;
-        }
-        case ViewMode.QUARTER: {
-          const monthOfQuarter = today.getMonth() % 3;
-          const monthPosition = monthOfQuarter / 3;
-          nowPosition = currentIndex * unitWidth + unitWidth * monthPosition;
-          break;
-        }
-        case ViewMode.YEAR: {
-          const monthOfYear = today.getMonth();
-          const yearMonthPosition = monthOfYear / 12;
-          nowPosition =
-            currentIndex * unitWidth + unitWidth * yearMonthPosition;
-          break;
-        }
-        default:
-          nowPosition = currentIndex * unitWidth + unitWidth / 2;
-      }
-
-      // Center the "now" position in the viewport
-      const containerWidth = container.clientWidth;
-      const scrollPosition = nowPosition - containerWidth / 2;
-
-      // Ensure we don't scroll beyond boundaries
-      const maxScroll = container.scrollWidth - containerWidth;
-      return Math.max(0, Math.min(maxScroll, scrollPosition));
-    };
-
-    // Helper to get time units for a specific view mode (used for scroll calculations)
-    const getTimeUnitsForMode = (mode: ViewMode): Date[] => {
-      switch (mode) {
-        case ViewMode.MINUTE:
-          return getMinutesBetween(
-            derivedStartDate,
-            derivedEndDate,
-            minuteStep,
-          );
-        case ViewMode.HOUR:
-          return getHoursBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.DAY:
-          return getDaysBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.WEEK:
-          return getWeeksBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.MONTH:
-          return getMonthsBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.QUARTER:
-          return getQuartersBetween(derivedStartDate, derivedEndDate);
-        case ViewMode.YEAR:
-          return getYearsBetween(derivedStartDate, derivedEndDate);
-        default:
-          return getMonthsBetween(derivedStartDate, derivedEndDate);
-      }
-    };
-
-    // Smooth scroll to "now" position
+    // Smooth-scroll so "now" is centered in the viewport.
     const scrollToNow = (mode: ViewMode, unitWidth: number) => {
-      if (!scrollContainerRef.current) {
-        return;
-      }
-
-      // Calculate timeUnits for the NEW mode directly (don't rely on state)
-      const newTimeUnits = getTimeUnitsForMode(mode);
-      const targetScroll = calculateScrollToNow(mode, unitWidth, newTimeUnits);
       const container = scrollContainerRef.current;
+      if (!container) return;
 
-      // Use smooth scroll behavior
+      const targetScale = new TimeScale(
+        mode,
+        derivedStartDate,
+        derivedEndDate,
+        unitWidth,
+        minuteStep,
+      );
+      const nowX = targetScale.dateToX(new Date());
+      const maxScroll = targetScale.totalWidth - container.clientWidth;
+      const target = Math.max(
+        0,
+        Math.min(maxScroll, nowX - container.clientWidth / 2),
+      );
+
       container.style.scrollBehavior = "smooth";
-      container.scrollLeft = targetScroll;
-
-      // Reset scroll behavior after animation completes
+      container.scrollLeft = target;
       setTimeout(() => {
-        if (container) {
-          container.style.scrollBehavior = "";
-        }
+        if (container) container.style.scrollBehavior = "";
       }, 500);
     };
 
     const handleViewModeChange = (newMode: ViewMode) => {
-      // Adjust unit width based on view mode
-      let newUnitWidth = 150;
-      switch (newMode) {
-        case ViewMode.MINUTE:
-          newUnitWidth = 60; // Wider for better visibility
-          break;
-        case ViewMode.HOUR:
-          newUnitWidth = 80; // Wider for better visibility
-          break;
-        case ViewMode.DAY:
-          newUnitWidth = 50;
-          break;
-        case ViewMode.WEEK:
-          newUnitWidth = 80;
-          break;
-        case ViewMode.MONTH:
-          newUnitWidth = 150;
-          break;
-        case ViewMode.QUARTER:
-          newUnitWidth = 180;
-          break;
-        case ViewMode.YEAR:
-          newUnitWidth = 200;
-          break;
-        default:
-          newUnitWidth = 150;
-      }
-
+      const newUnitWidth = defaultUnitWidth(newMode);
       setActiveViewMode(newMode);
       setViewUnitWidth(newUnitWidth);
+      onViewModeChange?.(newMode);
 
-      if (onViewModeChange) {
-        onViewModeChange(newMode);
-      }
-
-      // Scroll to "now" if focus mode is enabled
-      // Use requestAnimationFrame and setTimeout to ensure DOM has fully updated with new view mode
       if (focusMode) {
         requestAnimationFrame(() => {
-          setTimeout(() => {
-            scrollToNow(newMode, newUnitWidth);
-          }, 100);
+          setTimeout(() => scrollToNow(newMode, newUnitWidth), 100);
         });
       }
     };
 
-    // Initialize view mode
+    // Initialize view mode when the prop changes
     useEffect(() => {
       handleViewModeChange(viewMode);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [viewMode]);
 
     // Scroll to "now" when focus mode is initially enabled
     useEffect(() => {
       if (focusMode && scrollContainerRef.current) {
-        // Use a small delay to ensure DOM has updated after initial render
-        const timeoutId = setTimeout(() => {
-          scrollToNow(activeViewMode, viewUnitWidth);
-        }, 300);
+        const timeoutId = setTimeout(
+          () => scrollToNow(activeViewMode, viewUnitWidth),
+          300,
+        );
         return () => clearTimeout(timeoutId);
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [focusMode]);
 
     // Apply custom animation speed to CSS variables
@@ -924,17 +370,15 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
           speedValue.toString(),
         );
       }
-    }, [animationSpeed, containerRef.current]);
+    }, [animationSpeed]);
 
-    // Sticky headers: translate timeline headers and task-list header on vertical scroll
+    // Sticky headers: translate timeline headers and task-list header on scroll
     useEffect(() => {
       const scrollContainer = scrollContainerRef.current;
       if (!scrollContainer) return;
 
       const handleScroll = () => {
         const scrollTop = scrollContainer.scrollTop;
-
-        // Translate timeline headers
         const higherHeaders = scrollContainer.querySelectorAll<HTMLElement>(
           ".rmg-timeline-header-higher",
         );
@@ -951,19 +395,12 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         higherHeaders.forEach((el) => {
           el.style.transform = `translateY(${scrollTop}px)`;
         });
-
-        const higherHeaderHeight =
-          higherHeaders.length > 0 ? higherHeaders[0].offsetHeight : 0;
-
         mainHeaders.forEach((el) => {
           el.style.transform = `translateY(${scrollTop}px)`;
         });
-
         if (taskListHeader) {
           taskListHeader.style.transform = `translateY(${scrollTop}px)`;
         }
-
-        // Make today marker label sticky (stays at top)
         if (todayMarkerLabel) {
           todayMarkerLabel.style.transform = `translate(-50%, ${scrollTop}px)`;
         }
@@ -973,10 +410,9 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         passive: true,
       });
       return () => scrollContainer.removeEventListener("scroll", handleScroll);
-    }, [scrollContainerRef.current]);
+    }, []);
 
-    // Infinite scroll: proactively extend the timeline BEFORE the user hits the
-    // edge, so new area is already rendered and scrolling never stalls.
+    // Infinite scroll: proactively extend the timeline before reaching an edge.
     useEffect(() => {
       const container = scrollContainerRef.current;
       if (!container || !infiniteScroll || !onTimelineExtend) return;
@@ -990,8 +426,6 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         const maxScroll = container.scrollWidth - container.clientWidth;
         if (maxScroll <= 0) return;
 
-        // Start generating once the viewport gets within ~0.75 screens of an
-        // edge. Generous enough that the new units exist before they're needed.
         const threshold = Math.max(200, container.clientWidth * 0.75);
 
         if (container.scrollLeft >= maxScroll - threshold) {
@@ -1006,8 +440,6 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
           handleTimelineExtension("left");
         }
 
-        // Safety: if the parent ignores/clamps the extension (no size change),
-        // release the guard so future scrolls can retry.
         if (isExtendingRef.current) {
           window.setTimeout(() => {
             isExtendingRef.current = false;
@@ -1029,9 +461,8 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [infiniteScroll, onTimelineExtend]);
 
-    // After a left extension the timeline grows on the left, shifting every
-    // task right. Compensate the scroll position so the viewport stays put and
-    // tasks don't visibly jump. Runs synchronously before paint.
+    // After a left extension the timeline grows on the left; compensate the
+    // scroll position so the viewport stays put. Runs before paint.
     useLayoutEffect(() => {
       const container = scrollContainerRef.current;
       if (!container) return;
@@ -1040,20 +471,15 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         const { prevScrollWidth, prevScrollLeft } =
           pendingLeftExtendRef.current;
         const delta = container.scrollWidth - prevScrollWidth;
-        if (delta !== 0) {
-          container.scrollLeft = prevScrollLeft + delta;
-        }
+        if (delta !== 0) container.scrollLeft = prevScrollLeft + delta;
         pendingLeftExtendRef.current = null;
       }
 
-      // The new units have rendered — allow the next extension.
       isExtendingRef.current = false;
     }, [totalUnits]);
 
     // Resolve the effective extra dependency links to pass to DependencyLinks.
-    // "auto" chains each group's tasks chronologically (by startDate).
-    // An explicit array is passed through as-is.
-    const resolvedExtraLinks: DependencyLink[] = (() => {
+    const resolvedExtraLinks: DependencyLink[] = useMemo(() => {
       if (!dependencyLinks) return [];
       if (dependencyLinks === "auto") {
         const links: DependencyLink[] = [];
@@ -1071,24 +497,30 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
         return links;
       }
       return dependencyLinks;
-    })();
+    }, [dependencyLinks, tasks]);
 
-    const style: React.CSSProperties = {
-      fontSize: fontSize || "inherit",
-    };
+    // Total grid height (used by the today marker), computed once per render.
+    const totalGridHeight = useMemo(
+      () =>
+        tasks.reduce((total, group) => {
+          if (!group || !Array.isArray(group.tasks)) return total + 60;
+          const taskRows = CollisionService.detectOverlaps(
+            group.tasks,
+            activeViewMode,
+          );
+          return total + Math.max(60, taskRows.length * 40 + 20);
+        }, 0),
+      [tasks, activeViewMode],
+    );
 
-    // Apply dark mode class if enabled
+    const style: React.CSSProperties = { fontSize: fontSize || "inherit" };
     const themeClass = darkMode ? "rmg-dark" : "";
 
-    // Merge custom styles with component class names
-    const getComponentClassName = (component: string, defaultClass: string) => {
-      return `${defaultClass} ${styles[component as keyof typeof styles] || ""}`;
-    };
+    const getComponentClassName = (component: string, defaultClass: string) =>
+      `${defaultClass} ${styles[component as keyof typeof styles] || ""}`;
 
-    // Determine if we should show the view mode selector
     const shouldShowViewModeSelector = getAvailableViewModes() !== false;
 
-    // Custom render function for the header
     const renderHeaderContent = () => {
       if (renderHeader) {
         return renderHeader({
@@ -1131,12 +563,11 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
       );
     };
 
-    // Custom render function for the timeline header
     const renderTimelineHeaderContent = () => {
       if (renderTimelineHeader) {
         return renderTimelineHeader({
           timeUnits,
-          currentUnitIndex: currentUnitIndex,
+          currentUnitIndex,
           viewMode: activeViewMode,
           locale,
           unitWidth: viewUnitWidth,
@@ -1223,16 +654,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
                 {showCurrentDateMarker && currentUnitIndex >= 0 && (
                   <TodayMarker
                     currentMonthIndex={currentUnitIndex}
-                    // Calculate height based on actual row heights including collisions
-                    height={tasks.reduce((total, group) => {
-                      if (!group || !Array.isArray(group.tasks))
-                        return total + 60;
-                      const taskRows = CollisionService.detectOverlaps(
-                        group.tasks,
-                        activeViewMode,
-                      );
-                      return total + Math.max(60, taskRows.length * 40 + 20);
-                    }, 0)}
+                    height={totalGridHeight}
                     label={todayLabel}
                     dayOfMonth={currentDate.getDate()}
                     className={getComponentClassName(
@@ -1249,7 +671,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
 
                   return (
                     <TaskRow
-                      key={`task-row-${group.id}-${forceRender}`}
+                      key={`task-row-${group.id}`}
                       taskGroup={group}
                       startDate={derivedStartDate}
                       endDate={derivedEndDate}
@@ -1273,6 +695,7 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
                         "rmg-tooltip",
                       )}
                       viewMode={activeViewMode}
+                      minuteStep={minuteStep}
                       scrollContainerRef={scrollContainerRef}
                       smoothDragging={smoothDragging}
                       movementThreshold={movementThreshold}
@@ -1288,7 +711,6 @@ const GanttChart = forwardRef<GanttChartRef, GanttChartProps>(
 
                 {showDependencyLinks && (
                   <DependencyLinks
-                    key={`dep-links-${forceRender}`}
                     tasks={tasks}
                     startDate={derivedStartDate}
                     endDate={derivedEndDate}

--- a/src/components/task/TaskRow/index.tsx
+++ b/src/components/task/TaskRow/index.tsx
@@ -1,11 +1,31 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import { Task, ViewMode, TaskRowProps } from "@/types";
-import { TaskService, CollisionService } from "@/services";
+import { CollisionService } from "@/services";
+import { TimeScale, snapStart, snapEnd, shiftByUnits, unitMs } from "@/core";
 import TaskItem from "@/components/task/TaskItem";
 import { Tooltip } from "@/components/ui";
 
+type DragType = "move" | "resize-left" | "resize-right";
+
+interface DragState {
+  task: Task;
+  type: DragType;
+  // Pixel offset (grid space) between the cursor and the grabbed edge at the
+  // moment the drag started. Captured once; combined with the *current* grid
+  // position each frame so timeline extension / scrolling can never desync it.
+  grabOffset: number;
+  origStart: Date;
+  origEnd: Date;
+}
+
 /**
- * TaskRow Component - Displays and manages tasks for a single task group
+ * TaskRow — displays and manages the tasks of a single group.
+ *
+ * All dragging happens in date-space: pointer movement is converted to a date
+ * via the shared {@link TimeScale}, snapped to the view's unit grid, and stored
+ * as preview dates. Rendering always derives pixels from dates, so the bar, the
+ * header and the stored data stay perfectly consistent — and extending the
+ * timeline mid-drag simply re-derives positions from the (unchanged) dates.
  */
 const TaskRow: React.FC<TaskRowProps> = ({
   taskGroup,
@@ -25,479 +45,194 @@ const TaskRow: React.FC<TaskRowProps> = ({
   onTaskSelect,
   onAutoScrollChange,
   viewMode = ViewMode.MONTH,
+  minuteStep = 5,
   scrollContainerRef,
-  smoothDragging = true,
-  movementThreshold = 3,
-  animationSpeed = 0.25,
   infiniteScroll = false,
   onTimelineExtend,
   renderTask,
   renderTooltip,
   getTaskColor,
 }) => {
-  if (!taskGroup || !taskGroup.id || !Array.isArray(taskGroup.tasks)) {
-    return (
-      <div className="rmg-task-row rmg-task-row-invalid">
-        Invalid task group data
-      </div>
-    );
-  }
+  const isValidGroup =
+    !!taskGroup && !!taskGroup.id && Array.isArray(taskGroup.tasks);
+  const groupTasks: Task[] = isValidGroup ? taskGroup.tasks : [];
 
-  // Ensure valid dates
   const validStartDate = startDate instanceof Date ? startDate : new Date();
   const validEndDate = endDate instanceof Date ? endDate : new Date();
 
-  // Task interaction states
+  // Shared coordinate system for this row. Rebuilt only when the timeline
+  // bounds, view mode or unit width change.
+  const scale = useMemo(
+    () =>
+      new TimeScale(
+        viewMode,
+        validStartDate,
+        validEndDate,
+        monthWidth,
+        minuteStep,
+      ),
+    [
+      viewMode,
+      validStartDate.getTime(),
+      validEndDate.getTime(),
+      monthWidth,
+      minuteStep,
+    ],
+  );
+
   const [hoveredTask, setHoveredTask] = useState<Task | null>(null);
   const [draggingTask, setDraggingTask] = useState<Task | null>(null);
-  const [dragType, setDragType] = useState<
-    "move" | "resize-left" | "resize-right" | null
-  >(null);
-  const [dragStartX, setDragStartX] = useState(0);
-  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+  const [dragType, setDragType] = useState<DragType | null>(null);
   const [previewTask, setPreviewTask] = useState<Task | null>(null);
-  const [initialTaskState, setInitialTaskState] = useState<{
-    left: number;
-    width: number;
-    startDate: Date;
-    endDate: Date;
-  } | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
 
-  // Animation refs
-  const animationFrameRef = useRef<number | null>(null);
-  const lastMousePositionRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-  const targetPositionRef = useRef<{ left: number; width: number } | null>(
-    null,
-  );
-  const currentPositionRef = useRef<{ left: number; width: number } | null>(
-    null,
-  );
-  const velocityRef = useRef<{ left: number; width: number }>({
-    left: 0,
-    width: 0,
-  });
-  const lastUpdateTimeRef = useRef<number>(0);
-
-  // Auto-scrolling refs
-  const autoScrollActive = useRef<boolean>(false);
-  const autoScrollTimerRef = useRef<number | null>(null);
-  const autoScrollSpeedRef = useRef<number>(0);
-  const autoScrollDirectionRef = useRef<"left" | "right" | null>(null);
-  const timelineLimitsRef = useRef<{ minLeft: number; maxLeft: number }>({
-    minLeft: 0,
-    maxLeft: totalMonths * monthWidth,
-  });
-
-  // Refs for task interactions
   const rowRef = useRef<HTMLDivElement>(null);
-  const draggingTaskRef = useRef<Task | null>(null);
-  const previewTaskRef = useRef<Task | null>(null);
-  const taskElementRef = useRef<HTMLElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const previewRef = useRef<Task | null>(null);
+  const lastClientXRef = useRef(0);
+  // Always points at the latest scale so an in-flight drag (whose document
+  // listeners are closures from an earlier render) re-derives positions from
+  // the *current* timeline — essential when infinite scroll extends mid-drag.
+  const scaleRef = useRef(scale);
+  scaleRef.current = scale;
 
-  // Instance ID to prevent cross-chart interactions
+  // Auto-scroll bookkeeping
+  const autoScrollRaf = useRef<number | null>(null);
+  const autoScrollDir = useRef<"left" | "right" | null>(null);
+  const autoScrollSpeed = useRef(0);
+
   const instanceId = useRef(
     `task-row-${Math.random().toString(36).substring(2, 11)}`,
   );
 
-  // Calculate if we should use smooth dragging - DISABLED for day view
-  const shouldUseSmoothDragging = smoothDragging && viewMode !== ViewMode.DAY;
+  // Collision layout (one row of bars per non-overlapping lane). During a drag
+  // the preview task replaces its original so lanes reflow live.
+  const taskRows = useMemo(
+    () =>
+      previewTask
+        ? CollisionService.getPreviewArrangement(
+            previewTask,
+            groupTasks,
+            viewMode,
+          )
+        : CollisionService.detectOverlaps(groupTasks, viewMode),
+    [previewTask, groupTasks, viewMode],
+  );
 
-  // Task update helpers
-  const updateDraggingTask = (task: Task) => {
-    const taskCopy = {
-      ...task,
-      startDate: new Date(task.startDate),
-      endDate: new Date(task.endDate),
-    };
-    setDraggingTask(taskCopy);
-    draggingTaskRef.current = taskCopy;
-  };
-
-  const updatePreviewTask = (task: Task) => {
-    const taskCopy = {
-      ...task,
-      startDate: new Date(task.startDate),
-      endDate: new Date(task.endDate),
-    };
-    setPreviewTask(taskCopy);
-    previewTaskRef.current = taskCopy;
-  };
-
-  // Calculate task rows directly in the component using state
-  const taskRows = previewTask
-    ? CollisionService.getPreviewArrangement(
-        previewTask,
-        taskGroup.tasks,
-        viewMode,
-      )
-    : CollisionService.detectOverlaps(taskGroup.tasks, viewMode);
-
-  // Calculate row height based on task arrangement
   const rowHeight = Math.max(60, taskRows.length * 40 + 20);
 
-  // Update timeline limits for auto-scrolling
-  useEffect(() => {
-    timelineLimitsRef.current = {
-      minLeft: 0,
-      maxLeft: totalMonths * monthWidth,
-    };
-  }, [totalMonths, monthWidth]);
+  // ── Drag math ──────────────────────────────────────────────────────────────
 
-  // Animation function
-  const animateTaskMovement = () => {
-    if (
-      !taskElementRef.current ||
-      !targetPositionRef.current ||
-      !currentPositionRef.current
-    ) {
-      animationFrameRef.current = null;
+  /** Cursor x in grid-content coordinates (0 = timeline start). */
+  const gridX = (clientX: number): number => {
+    if (!rowRef.current) return 0;
+    return clientX - rowRef.current.getBoundingClientRect().left;
+  };
+
+  const setPreview = (task: Task) => {
+    const copy = {
+      ...task,
+      startDate: new Date(task.startDate),
+      endDate: new Date(task.endDate),
+    };
+    previewRef.current = copy;
+    setPreviewTask(copy);
+  };
+
+  /** Recompute the preview task from the current cursor + scale. */
+  const recomputePreview = () => {
+    const drag = dragRef.current;
+    if (!drag) return;
+
+    const scale = scaleRef.current;
+    const desiredLeftPx = gridX(lastClientXRef.current) - drag.grabOffset;
+    const step = unitMs(viewMode, minuteStep);
+
+    if (drag.type === "move") {
+      // Shift both edges by a whole number of units → duration is preserved.
+      const rawStart = scale.xToDate(desiredLeftPx);
+      const deltaUnits = Math.round(
+        (rawStart.getTime() - drag.origStart.getTime()) / step,
+      );
+      const newStart = shiftByUnits(
+        drag.origStart,
+        viewMode,
+        deltaUnits,
+        minuteStep,
+      );
+      const newEnd = shiftByUnits(
+        drag.origEnd,
+        viewMode,
+        deltaUnits,
+        minuteStep,
+      );
+      setPreview({ ...drag.task, startDate: newStart, endDate: newEnd });
+    } else if (drag.type === "resize-left") {
+      let newStart = snapStart(
+        scale.xToDate(desiredLeftPx),
+        viewMode,
+        minuteStep,
+      );
+      const maxStart = snapStart(drag.origEnd, viewMode, minuteStep);
+      if (newStart.getTime() > maxStart.getTime()) newStart = maxStart;
+      setPreview({ ...drag.task, startDate: newStart, endDate: drag.origEnd });
+    } else {
+      const desiredRightPx = gridX(lastClientXRef.current) - drag.grabOffset;
+      // Right edge is exclusive: nudge inward so a boundary belongs to the
+      // column on its left.
+      let newEnd = snapEnd(
+        scale.xToDate(desiredRightPx - 0.001),
+        viewMode,
+        minuteStep,
+      );
+      const minEnd = snapEnd(drag.origStart, viewMode, minuteStep);
+      if (newEnd.getTime() < minEnd.getTime()) newEnd = minEnd;
+      setPreview({ ...drag.task, startDate: drag.origStart, endDate: newEnd });
+    }
+  };
+
+  const handleMouseDown = (
+    event: React.MouseEvent,
+    task: Task,
+    type: DragType,
+  ) => {
+    if (!editMode) return;
+    if (type === "move" && !allowTaskMove) return;
+    if ((type === "resize-left" || type === "resize-right") && !allowTaskResize)
       return;
-    }
 
-    const now = Date.now();
-    const elapsed = now - lastUpdateTimeRef.current;
-    lastUpdateTimeRef.current = now;
+    event.preventDefault();
+    event.stopPropagation();
 
-    // Smooth animation coefficient
-    const easing = animationSpeed || 0.25;
+    const origStart = new Date(task.startDate);
+    const origEnd = new Date(task.endDate);
+    const cursorGridX = gridX(event.clientX);
+    const edgePx =
+      type === "resize-right"
+        ? scale.dateToX(origEnd)
+        : scale.dateToX(origStart);
 
-    // Calculate new position with easing
-    const newLeft =
-      currentPositionRef.current.left +
-      (targetPositionRef.current.left - currentPositionRef.current.left) *
-        easing;
-    const newWidth =
-      currentPositionRef.current.width +
-      (targetPositionRef.current.width - currentPositionRef.current.width) *
-        easing;
-
-    // Update velocity for more natural animation
-    velocityRef.current.left =
-      (newLeft - currentPositionRef.current.left) / (elapsed || 16);
-    velocityRef.current.width =
-      (newWidth - currentPositionRef.current.width) / (elapsed || 16);
-
-    // Update current position
-    currentPositionRef.current = { left: newLeft, width: newWidth };
-
-    // Apply to DOM - direct DOM manipulation
-    taskElementRef.current.style.left = `${newLeft}px`;
-    taskElementRef.current.style.width = `${newWidth}px`;
-
-    // Calculate and update dates based on current position
-    if (draggingTaskRef.current) {
-      updateDatesFromPosition(newLeft, newWidth);
-    }
-
-    // Continue animation loop
-    animationFrameRef.current = requestAnimationFrame(animateTaskMovement);
-  };
-
-  // Update dates based on visual position with special Day view handling
-  const updateDatesFromPosition = (left: number, width: number) => {
-    if (!draggingTaskRef.current) return;
-
-    try {
-      // For day view, apply precise date calculation
-      if (viewMode === ViewMode.DAY) {
-        // Calculate days from start position
-        const daysFromStart = Math.round(left / monthWidth);
-
-        // Calculate exact days span
-        const daysSpan = Math.max(1, Math.round(width / monthWidth));
-
-        // Apply precise day calculations
-        const baseDate = new Date(validStartDate);
-        baseDate.setHours(0, 0, 0, 0);
-
-        const newStartDate = new Date(baseDate);
-        newStartDate.setDate(baseDate.getDate() + daysFromStart);
-        newStartDate.setHours(0, 0, 0, 0);
-
-        const newEndDate = new Date(newStartDate);
-        newEndDate.setDate(newStartDate.getDate() + daysSpan - 1);
-        newEndDate.setHours(23, 59, 59, 999);
-
-        // Ensure dates are within the timeline boundaries
-        const startTime = validStartDate.getTime();
-        const endTime = validEndDate.getTime();
-
-        const constrainedStartDate = new Date(
-          Math.max(startTime, newStartDate.getTime()),
-        );
-        const constrainedEndDate = new Date(
-          Math.min(endTime, newEndDate.getTime()),
-        );
-
-        // Create updated task with the new dates
-        const updatedTask = {
-          ...draggingTaskRef.current,
-          startDate: constrainedStartDate,
-          endDate: constrainedEndDate,
-        };
-
-        // Update preview state
-        updatePreviewTask(updatedTask);
-      } else {
-        // Use TaskService for regular calculation
-        const { newStartDate, newEndDate } =
-          TaskService.calculateDatesFromPosition(
-            left,
-            width,
-            validStartDate,
-            validEndDate,
-            totalMonths,
-            monthWidth,
-            viewMode,
-          );
-
-        const updatedTask = {
-          ...draggingTaskRef.current,
-          startDate: newStartDate,
-          endDate: newEndDate,
-        };
-
-        updatePreviewTask(updatedTask);
-      }
-    } catch (error) {
-      console.error("Error updating dates:", error);
-    }
-  };
-
-  // Auto-scroll functions
-  const checkForAutoScroll = (clientX: number) => {
-    if (!scrollContainerRef?.current || !draggingTask) return;
-
-    const container = scrollContainerRef.current;
-    const containerRect = container.getBoundingClientRect();
-
-    // Define the edge threshold area (in pixels) to trigger auto-scrolling
-    const edgeThreshold = 40;
-
-    // Reset auto-scroll direction
-    let direction: "left" | "right" | null = null;
-    let scrollSpeed = 0;
-
-    // Check if mouse is near the left edge
-    if (clientX < containerRect.left + edgeThreshold) {
-      direction = "left";
-      // Calculate scroll speed based on proximity to edge (closer = faster)
-      scrollSpeed = Math.max(
-        1,
-        Math.round((edgeThreshold - (clientX - containerRect.left)) / 10),
-      );
-    }
-    // Check if mouse is near the right edge
-    else if (clientX > containerRect.right - edgeThreshold) {
-      direction = "right";
-      // Calculate scroll speed based on proximity to edge (closer = faster)
-      scrollSpeed = Math.max(
-        1,
-        Math.round((clientX - (containerRect.right - edgeThreshold)) / 10),
-      );
-    }
-
-    // Update refs with current auto-scroll state
-    autoScrollDirectionRef.current = direction;
-    autoScrollSpeedRef.current = scrollSpeed;
-
-    // Start or stop auto-scrolling based on direction
-    if (direction && !autoScrollActive.current) {
-      startAutoScroll();
-      if (onAutoScrollChange) onAutoScrollChange(true);
-    } else if (!direction && autoScrollActive.current) {
-      stopAutoScroll();
-      if (onAutoScrollChange) onAutoScrollChange(false);
-    }
-  };
-
-  // Start auto-scrolling with infinite scroll support - IMPROVED for smoother scrolling
-  const startAutoScroll = () => {
-    if (autoScrollActive.current) return;
-
-    autoScrollActive.current = true;
-
-    // Disable smooth scroll behavior during auto-scroll for better performance
-    if (scrollContainerRef?.current) {
-      scrollContainerRef.current.style.scrollBehavior = "auto";
-    }
-
-    // Use requestAnimationFrame for smoother scrolling with easing
-    let lastTime = performance.now();
-    const doScroll = () => {
-      if (
-        !autoScrollActive.current ||
-        !scrollContainerRef?.current ||
-        !targetPositionRef.current
-      )
-        return;
-
-      const now = performance.now();
-      const deltaTime = Math.min(now - lastTime, 16); // Cap at ~60fps
-      lastTime = now;
-
-      const container = scrollContainerRef.current;
-      const direction = autoScrollDirectionRef.current;
-      const speed = autoScrollSpeedRef.current;
-
-      // Get current scroll position
-      const currentScrollLeft = container.scrollLeft;
-      // Get maximum scroll position
-      const maxScrollLeft = container.scrollWidth - container.clientWidth;
-
-      // Apply easing for smoother acceleration/deceleration
-      const easingFactor = 0.15; // Smooth interpolation
-      const frameSpeed = speed * (deltaTime / 16); // Normalize to frame time
-
-      if (direction === "left") {
-        // Check if we're at the beginning and should extend timeline
-        if (currentScrollLeft <= 0) {
-          if (infiniteScroll && onTimelineExtend) {
-            // Trigger timeline extension to the left
-            onTimelineExtend("left");
-            stopAutoScroll();
-            return;
-          }
-          stopAutoScroll();
-          return;
-        }
-
-        // Calculate actual scroll amount
-        const scrollAmount = Math.min(frameSpeed * 3, currentScrollLeft); // Faster scroll, bounded
-        const newScrollLeft = currentScrollLeft - scrollAmount;
-        container.scrollLeft = newScrollLeft;
-
-        // When scrolling left (viewport moves left), the task should move left on the timeline
-        // to stay in the same visual position relative to the mouse
-        if (targetPositionRef.current && taskElementRef.current) {
-          const currentLeft = parseFloat(
-            taskElementRef.current.style.left || "0",
-          );
-          // Move task left by the same amount we scrolled
-          const adjustedLeft = Math.max(
-            timelineLimitsRef.current.minLeft,
-            currentLeft - scrollAmount,
-          );
-          targetPositionRef.current.left = adjustedLeft;
-          if (currentPositionRef.current) {
-            currentPositionRef.current.left = adjustedLeft;
-          }
-
-          // Apply position immediately to keep task visible
-          taskElementRef.current.style.left = `${adjustedLeft}px`;
-
-          // Update dates based on new position
-          if (draggingTaskRef.current) {
-            updateDatesFromPosition(
-              adjustedLeft,
-              targetPositionRef.current.width,
-            );
-          }
-        }
-      } else if (direction === "right") {
-        // Check if we're at the end and should extend timeline
-        if (currentScrollLeft >= maxScrollLeft) {
-          if (infiniteScroll && onTimelineExtend) {
-            // Trigger timeline extension to the right
-            onTimelineExtend("right");
-            stopAutoScroll();
-            return;
-          }
-          stopAutoScroll();
-          return;
-        }
-
-        // Calculate actual scroll amount
-        const scrollAmount = Math.min(
-          frameSpeed * 3,
-          maxScrollLeft - currentScrollLeft,
-        ); // Faster scroll, bounded
-        const newScrollLeft = currentScrollLeft + scrollAmount;
-        container.scrollLeft = newScrollLeft;
-
-        // When scrolling right (viewport moves right), the task should move right on the timeline
-        // to stay in the same visual position relative to the mouse
-        if (
-          targetPositionRef.current &&
-          taskElementRef.current &&
-          initialTaskState
-        ) {
-          const currentLeft = parseFloat(
-            taskElementRef.current.style.left || "0",
-          );
-          const maxLeftPosition =
-            timelineLimitsRef.current.maxLeft - targetPositionRef.current.width;
-          // Move task right by the same amount we scrolled
-          const adjustedLeft = Math.min(
-            maxLeftPosition,
-            currentLeft + scrollAmount,
-          );
-          targetPositionRef.current.left = adjustedLeft;
-          if (currentPositionRef.current) {
-            currentPositionRef.current.left = adjustedLeft;
-          }
-
-          // Apply position immediately to keep task visible
-          taskElementRef.current.style.left = `${adjustedLeft}px`;
-
-          // Update dates based on new position
-          if (draggingTaskRef.current) {
-            updateDatesFromPosition(
-              adjustedLeft,
-              targetPositionRef.current.width,
-            );
-          }
-        }
-      }
-
-      // Continue scrolling if active
-      if (autoScrollActive.current) {
-        autoScrollTimerRef.current = requestAnimationFrame(doScroll);
-      }
+    dragRef.current = {
+      task,
+      type,
+      grabOffset: cursorGridX - edgePx,
+      origStart,
+      origEnd,
     };
+    lastClientXRef.current = event.clientX;
 
-    autoScrollTimerRef.current = requestAnimationFrame(doScroll);
+    setDraggingTask(task);
+    setDragType(type);
+    setPreview(task);
+
+    document.addEventListener("mousemove", handleDocMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
   };
 
-  // Stop auto-scrolling
-  const stopAutoScroll = () => {
-    autoScrollActive.current = false;
-    if (autoScrollTimerRef.current !== null) {
-      cancelAnimationFrame(autoScrollTimerRef.current);
-      autoScrollTimerRef.current = null;
-    }
+  const handleDocMouseMove = (e: MouseEvent) => {
+    if (!dragRef.current) return;
+    lastClientXRef.current = e.clientX;
 
-    // Re-enable smooth scroll behavior after auto-scroll stops
-    if (scrollContainerRef?.current) {
-      scrollContainerRef.current.style.scrollBehavior = "";
-    }
-  };
-
-  // Task interaction handlers
-  const handleTaskClick = (event: React.MouseEvent, task: Task) => {
-    if (onTaskClick && !draggingTask) {
-      onTaskClick(task, taskGroup);
-    }
-
-    if (onTaskSelect) {
-      onTaskSelect(task, true);
-    }
-  };
-
-  const handleTaskMouseEnter = (event: React.MouseEvent, task: Task) => {
-    if (!draggingTask) {
-      setHoveredTask(task);
-      updateTooltipPosition(event);
-    }
-  };
-
-  const handleTaskMouseLeave = () => {
-    if (!draggingTask) {
-      setHoveredTask(null);
-    }
-  };
-
-  const updateTooltipPosition = (e: React.MouseEvent | MouseEvent) => {
     if (rowRef.current) {
       const rect = rowRef.current.getBoundingClientRect();
       setTooltipPosition({
@@ -505,360 +240,178 @@ const TaskRow: React.FC<TaskRowProps> = ({
         y: e.clientY - rect.top,
       });
     }
-  };
 
-  const handleMouseDown = (
-    event: React.MouseEvent,
-    task: Task,
-    type: "move" | "resize-left" | "resize-right",
-  ) => {
-    if (!editMode) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Find the task element
-    const taskEl = document.querySelector(
-      `[data-task-id="${task.id}"][data-instance-id="${instanceId.current}"]`,
-    ) as HTMLElement;
-
-    if (!taskEl) return;
-    taskElementRef.current = taskEl;
-
-    // Store the initial state
-    const initialLeft = parseFloat(taskEl.style.left || "0");
-    const initialWidth = parseFloat(taskEl.style.width || "0");
-
-    setInitialTaskState({
-      left: initialLeft,
-      width: initialWidth,
-      startDate: new Date(task.startDate),
-      endDate: new Date(task.endDate),
-    });
-
-    // Initialize animation refs
-    targetPositionRef.current = { left: initialLeft, width: initialWidth };
-    currentPositionRef.current = { left: initialLeft, width: initialWidth };
-    lastMousePositionRef.current = { x: event.clientX, y: event.clientY };
-    lastUpdateTimeRef.current = Date.now();
-    velocityRef.current = { left: 0, width: 0 };
-
-    // Update task element data attribute for styling
-    taskEl.setAttribute("data-dragging", "true");
-
-    if (shouldUseSmoothDragging) {
-      taskEl.style.transition = "none"; // We'll handle the animation manually
-    } else {
-      taskEl.style.transition = "none";
-    }
-
-    // Set up dragging state
-    setDraggingTask(task);
-    setDragType(type);
-    setDragStartX(event.clientX);
-    setPreviewTask(task);
-
-    updateDraggingTask(task);
-    updatePreviewTask(task);
-
-    // Start animation loop (only for smooth dragging)
-    if (animationFrameRef.current === null && shouldUseSmoothDragging) {
-      animationFrameRef.current = requestAnimationFrame(animateTaskMovement);
-    }
-
-    // Add global event listeners
-    document.addEventListener("mouseup", handleMouseUp);
-    document.addEventListener(
-      "mousemove",
-      handleMouseMove as unknown as EventListener,
-    );
-  };
-
-  const handleMouseMove = (e: React.MouseEvent | MouseEvent) => {
-    // Store current mouse position for animation
-    lastMousePositionRef.current = { x: e.clientX, y: e.clientY };
-
-    // Update tooltip position
-    if (e instanceof MouseEvent && hoveredTask && rowRef.current) {
-      const rect = rowRef.current.getBoundingClientRect();
-      setTooltipPosition({
-        x: e.clientX - rect.left + 20,
-        y: e.clientY - rect.top,
-      });
-    } else if (!(e instanceof MouseEvent)) {
-      updateTooltipPosition(e as React.MouseEvent);
-    }
-
-    // Check for auto-scrolling when dragging
-    if (draggingTask && scrollContainerRef?.current) {
-      checkForAutoScroll(e.clientX);
-    }
-
-    // Handle task dragging and resizing
-    if (
-      draggingTask &&
-      dragType &&
-      initialTaskState &&
-      rowRef.current &&
-      targetPositionRef.current
-    ) {
-      try {
-        // Calculate the total movement since drag started
-        const totalDeltaX = e.clientX - dragStartX;
-
-        // Get the timeline's total width
-        const totalWidth = totalMonths * monthWidth;
-
-        // Calculate new target position based on drag type
-        let newLeft = targetPositionRef.current.left;
-        let newWidth = targetPositionRef.current.width;
-
-        switch (dragType) {
-          case "move":
-            // Move task with bounds checking
-            newLeft = Math.max(
-              0,
-              Math.min(
-                totalWidth - initialTaskState.width,
-                initialTaskState.left + totalDeltaX,
-              ),
-            );
-
-            // Special handling for day view (immediate snapping)
-            if (viewMode === ViewMode.DAY) {
-              newLeft = Math.round(newLeft / monthWidth) * monthWidth;
-            }
-            break;
-
-          case "resize-left":
-            // Resize from left with minimum width
-            const maxLeftDelta = initialTaskState.width - 20;
-            const leftDelta = Math.min(maxLeftDelta, totalDeltaX);
-
-            newLeft = Math.max(0, initialTaskState.left + leftDelta);
-
-            // Special handling for day view (immediate snapping)
-            if (viewMode === ViewMode.DAY) {
-              newLeft = Math.round(newLeft / monthWidth) * monthWidth;
-            }
-
-            // Calculate width to maintain right edge position
-            const rightEdge = initialTaskState.left + initialTaskState.width;
-            newWidth = Math.max(20, rightEdge - newLeft);
-
-            // Special handling for day view (ensure full day widths)
-            if (viewMode === ViewMode.DAY) {
-              newWidth = Math.round(newWidth / monthWidth) * monthWidth;
-              newWidth = Math.max(monthWidth, newWidth); // Minimum one day
-            }
-            break;
-
-          case "resize-right":
-            // Resize from right with minimum width
-            newWidth = Math.max(
-              20,
-              Math.min(
-                totalWidth - initialTaskState.left,
-                initialTaskState.width + totalDeltaX,
-              ),
-            );
-
-            // Special handling for day view (ensure full day widths)
-            if (viewMode === ViewMode.DAY) {
-              newWidth = Math.round(newWidth / monthWidth) * monthWidth;
-              newWidth = Math.max(monthWidth, newWidth); // Minimum one day
-            }
-            break;
-        }
-
-        // Update target position reference
-        targetPositionRef.current = { left: newLeft, width: newWidth };
-
-        // Apply position immediately for day view mode
-        if (viewMode === ViewMode.DAY && taskElementRef.current) {
-          taskElementRef.current.style.left = `${newLeft}px`;
-          taskElementRef.current.style.width = `${newWidth}px`;
-          updateDatesFromPosition(newLeft, newWidth);
-        }
-        // Start animation for smooth dragging in other view modes
-        else if (shouldUseSmoothDragging) {
-          if (animationFrameRef.current === null) {
-            lastUpdateTimeRef.current = Date.now();
-            animationFrameRef.current =
-              requestAnimationFrame(animateTaskMovement);
-          }
-        }
-        // Direct update for non-smooth non-day view modes
-        else if (taskElementRef.current) {
-          taskElementRef.current.style.left = `${newLeft}px`;
-          taskElementRef.current.style.width = `${newWidth}px`;
-          updateDatesFromPosition(newLeft, newWidth);
-        }
-      } catch (error) {
-        console.error("Error in handleMouseMove:", error);
-      }
-    }
-  };
-
-  // Finalize task positioning on mouse up with special day view handling
-  const finalizeTaskPosition = () => {
-    if (
-      !taskElementRef.current ||
-      !targetPositionRef.current ||
-      !draggingTaskRef.current
-    )
-      return;
-
-    // Get final position
-    let finalLeft = targetPositionRef.current.left;
-    let finalWidth = targetPositionRef.current.width;
-
-    // Apply snapping for final position in day mode
-    if (viewMode === ViewMode.DAY) {
-      // Snap to day grid
-      finalLeft = Math.round(finalLeft / monthWidth) * monthWidth;
-      finalWidth = Math.round(finalWidth / monthWidth) * monthWidth;
-
-      // Ensure minimum width
-      finalWidth = Math.max(monthWidth, finalWidth);
-
-      // Apply final position to element with transition
-      taskElementRef.current.style.transition =
-        "transform 0.15s ease-out, left 0.15s ease-out, width 0.15s ease-out";
-      taskElementRef.current.style.left = `${finalLeft}px`;
-      taskElementRef.current.style.width = `${finalWidth}px`;
-
-      // Update dates from the snapped position
-      updateDatesFromPosition(finalLeft, finalWidth);
-    }
-    // Apply snapping for other modes if desired
-    else if (!shouldUseSmoothDragging) {
-      taskElementRef.current.style.transition =
-        "transform 0.15s ease-out, left 0.15s ease-out, width 0.15s ease-out";
-      taskElementRef.current.style.left = `${finalLeft}px`;
-      taskElementRef.current.style.width = `${finalWidth}px`;
-    }
-
-    // Calculate final dates
-    let finalTask = previewTaskRef.current;
-    if (!finalTask) return;
-
-    // Verify final task is within timeline bounds
-    const timelineStartTime = validStartDate.getTime();
-    const timelineEndTime = validEndDate.getTime();
-
-    // Ensure task dates are within bounds
-    if (finalTask.startDate.getTime() < timelineStartTime) {
-      finalTask = {
-        ...finalTask,
-        startDate: new Date(timelineStartTime),
-      };
-    }
-
-    if (finalTask.endDate.getTime() > timelineEndTime) {
-      finalTask = {
-        ...finalTask,
-        endDate: new Date(timelineEndTime),
-      };
-    }
-
-    // Call update handler with the final task
-    if (onTaskUpdate && finalTask) {
-      try {
-        onTaskUpdate(taskGroup.id, finalTask);
-      } catch (error) {
-        console.error("Error in onTaskUpdate:", error);
-      }
-    }
+    recomputePreview();
+    checkAutoScroll(e.clientX);
   };
 
   const handleMouseUp = () => {
+    document.removeEventListener("mousemove", handleDocMouseMove);
+    document.removeEventListener("mouseup", handleMouseUp);
+    stopAutoScroll();
+
+    const finalTask = previewRef.current;
+    const groupId = taskGroup.id;
+
+    // Reset drag state first so the row re-renders from the real task data.
+    dragRef.current = null;
+    previewRef.current = null;
+    setDraggingTask(null);
+    setDragType(null);
+    setPreviewTask(null);
+
+    if (!finalTask || !onTaskUpdate) return;
+
+    let start = new Date(finalTask.startDate);
+    let end = new Date(finalTask.endDate);
+
+    // Keep the result inside the timeline unless the host opts into growth.
+    if (!infiniteScroll) {
+      if (start.getTime() < validStartDate.getTime())
+        start = new Date(validStartDate);
+      if (end.getTime() > validEndDate.getTime()) end = new Date(validEndDate);
+    }
+
     try {
-      // Cancel any ongoing animation
-      if (animationFrameRef.current !== null) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
-
-      // Finalize task position with snapping
-      finalizeTaskPosition();
-
-      // Clean up animation state
-      if (taskElementRef.current) {
-        // Reset the dragging state
-        taskElementRef.current.setAttribute("data-dragging", "false");
-
-        // Reset transitions after a short delay to allow final animation to complete
-        setTimeout(() => {
-          if (taskElementRef.current) {
-            taskElementRef.current.style.transition = "";
-          }
-        }, 200);
-      }
+      onTaskUpdate(groupId, { ...finalTask, startDate: start, endDate: end });
     } catch (error) {
-      console.error("Error in handleMouseUp:", error);
-    } finally {
-      // Stop auto-scrolling
-      stopAutoScroll();
-      if (onAutoScrollChange) onAutoScrollChange(false);
-
-      // Reset all drag states
-      setDraggingTask(null);
-      setDragType(null);
-      setPreviewTask(null);
-      setInitialTaskState(null);
-      draggingTaskRef.current = null;
-      previewTaskRef.current = null;
-      taskElementRef.current = null;
-      targetPositionRef.current = null;
-      currentPositionRef.current = null;
-
-      // Remove global event listeners
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.removeEventListener(
-        "mousemove",
-        handleMouseMove as unknown as EventListener,
-      );
+      console.error("Error in onTaskUpdate:", error);
     }
   };
 
-  // Handle progress update
+  // ── Auto-scroll while dragging near an edge ─────────────────────────────────
+
+  const checkAutoScroll = (clientX: number) => {
+    const container = scrollContainerRef?.current;
+    if (!container || !dragRef.current) return;
+
+    const rect = container.getBoundingClientRect();
+    const edge = 40;
+    let dir: "left" | "right" | null = null;
+    let speed = 0;
+
+    if (clientX < rect.left + edge) {
+      dir = "left";
+      speed = Math.max(1, Math.round((rect.left + edge - clientX) / 10));
+    } else if (clientX > rect.right - edge) {
+      dir = "right";
+      speed = Math.max(1, Math.round((clientX - (rect.right - edge)) / 10));
+    }
+
+    autoScrollDir.current = dir;
+    autoScrollSpeed.current = speed;
+
+    if (dir && autoScrollRaf.current === null) {
+      onAutoScrollChange?.(true);
+      autoScrollRaf.current = requestAnimationFrame(autoScrollStep);
+    } else if (!dir) {
+      stopAutoScroll();
+    }
+  };
+
+  const autoScrollStep = () => {
+    const container = scrollContainerRef?.current;
+    const dir = autoScrollDir.current;
+    if (!container || !dir || !dragRef.current) {
+      autoScrollRaf.current = null;
+      return;
+    }
+
+    const maxScroll = container.scrollWidth - container.clientWidth;
+    const amount = autoScrollSpeed.current * 3;
+
+    if (dir === "left") {
+      if (container.scrollLeft <= 0) {
+        if (infiniteScroll && onTimelineExtend) onTimelineExtend("left");
+        stopAutoScroll();
+        return;
+      }
+      container.scrollLeft = Math.max(0, container.scrollLeft - amount);
+    } else {
+      if (container.scrollLeft >= maxScroll) {
+        if (infiniteScroll && onTimelineExtend) onTimelineExtend("right");
+        stopAutoScroll();
+        return;
+      }
+      container.scrollLeft = Math.min(maxScroll, container.scrollLeft + amount);
+    }
+
+    recomputePreview();
+    autoScrollRaf.current = requestAnimationFrame(autoScrollStep);
+  };
+
+  const stopAutoScroll = () => {
+    if (autoScrollRaf.current !== null) {
+      cancelAnimationFrame(autoScrollRaf.current);
+      autoScrollRaf.current = null;
+    }
+    autoScrollDir.current = null;
+    onAutoScrollChange?.(false);
+  };
+
+  // ── Hover / click / progress ────────────────────────────────────────────────
+
+  const handleRowMouseMove = (e: React.MouseEvent) => {
+    if (dragRef.current || !hoveredTask || !rowRef.current) return;
+    const rect = rowRef.current.getBoundingClientRect();
+    setTooltipPosition({
+      x: e.clientX - rect.left + 20,
+      y: e.clientY - rect.top,
+    });
+  };
+
+  const handleTaskClick = (_event: React.MouseEvent, task: Task) => {
+    if (dragRef.current) return;
+    onTaskClick?.(task, taskGroup);
+    onTaskSelect?.(task, true);
+  };
+
+  const handleTaskMouseEnter = (event: React.MouseEvent, task: Task) => {
+    if (dragRef.current) return;
+    setHoveredTask(task);
+    if (rowRef.current) {
+      const rect = rowRef.current.getBoundingClientRect();
+      setTooltipPosition({
+        x: event.clientX - rect.left + 20,
+        y: event.clientY - rect.top,
+      });
+    }
+  };
+
+  const handleTaskMouseLeave = () => {
+    if (!dragRef.current) setHoveredTask(null);
+  };
+
   const handleProgressUpdate = (task: Task, newPercent: number) => {
     if (onTaskUpdate && taskGroup.id) {
       try {
-        // Create updated task with new progress percentage
-        const updatedTask = {
-          ...task,
-          percent: newPercent,
-        };
-
-        // Call the onTaskUpdate handler with the updated task
-        onTaskUpdate(taskGroup.id, updatedTask);
+        onTaskUpdate(taskGroup.id, { ...task, percent: newPercent });
       } catch (error) {
         console.error("Error updating task progress:", error);
       }
     }
   };
 
-  // Clean up event listeners and animations on unmount
+  // Clean up listeners on unmount.
   useEffect(() => {
     return () => {
+      document.removeEventListener("mousemove", handleDocMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
-      document.removeEventListener(
-        "mousemove",
-        handleMouseMove as unknown as EventListener,
-      );
-      stopAutoScroll();
-
-      if (animationFrameRef.current !== null) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
+      if (autoScrollRaf.current !== null)
+        cancelAnimationFrame(autoScrollRaf.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Handle empty task groups
-  if (!taskGroup.tasks || taskGroup.tasks.length === 0) {
+  if (!isValidGroup) {
+    return (
+      <div className="rmg-task-row rmg-task-row-invalid">
+        Invalid task group data
+      </div>
+    );
+  }
+
+  if (groupTasks.length === 0) {
     return (
       <div className="rmg-task-row rmg-task-row-empty">No tasks available</div>
     );
@@ -869,9 +422,9 @@ const TaskRow: React.FC<TaskRowProps> = ({
       className={`rmg-task-row ${className}`}
       style={{
         height: `${rowHeight}px`,
-        minWidth: `${totalMonths * monthWidth}px`,
+        minWidth: `${scale.totalWidth}px`,
       }}
-      onMouseMove={(e) => handleMouseMove(e)}
+      onMouseMove={handleRowMouseMove}
       onMouseLeave={() => setHoveredTask(null)}
       ref={rowRef}
       data-testid={`task-row-${taskGroup.id}`}
@@ -879,69 +432,52 @@ const TaskRow: React.FC<TaskRowProps> = ({
       data-rmg-component="task-row"
       data-group-id={taskGroup.id}
     >
-      {/* Render tasks by row to prevent overlaps */}
       {taskRows.map((rowTasks, rowIndex) => (
-        <React.Fragment key={`task-row-${rowIndex}`}>
+        <React.Fragment key={`lane-${rowIndex}`}>
           {rowTasks.map((task) => {
-            try {
-              if (
-                !task ||
-                !task.id ||
-                !(task.startDate instanceof Date) ||
-                !(task.endDate instanceof Date)
-              ) {
-                console.warn("Invalid task data:", task);
-                return null;
-              }
-
-              // Calculate task position
-              const { leftPx, widthPx } =
-                TaskService.calculateTaskPixelPosition(
-                  task,
-                  validStartDate,
-                  validEndDate,
-                  totalMonths,
-                  monthWidth,
-                  viewMode,
-                );
-
-              const isHovered = hoveredTask?.id === task.id;
-              const isDragging = draggingTask?.id === task.id;
-              const topPx = rowIndex * 40 + 10;
-
-              return (
-                <TaskItem
-                  key={`task-${task.id}`}
-                  task={task}
-                  leftPx={leftPx}
-                  widthPx={widthPx}
-                  topPx={topPx}
-                  isHovered={isHovered}
-                  isDragging={isDragging}
-                  editMode={editMode}
-                  allowProgressEdit={allowProgressEdit}
-                  allowTaskResize={allowTaskResize}
-                  allowTaskMove={allowTaskMove}
-                  showProgress={showProgress}
-                  instanceId={instanceId.current}
-                  onMouseDown={handleMouseDown}
-                  onMouseEnter={handleTaskMouseEnter}
-                  onMouseLeave={handleTaskMouseLeave}
-                  onClick={handleTaskClick}
-                  renderTask={renderTask}
-                  getTaskColor={getTaskColor}
-                  onProgressUpdate={handleProgressUpdate}
-                />
-              );
-            } catch (error) {
-              console.error("Error rendering task:", error);
+            if (
+              !task ||
+              !task.id ||
+              !(task.startDate instanceof Date) ||
+              !(task.endDate instanceof Date)
+            ) {
               return null;
             }
+
+            const { leftPx, widthPx } = scale.positionTask(
+              task.startDate,
+              task.endDate,
+            );
+            const isDragging = draggingTask?.id === task.id;
+
+            return (
+              <TaskItem
+                key={`task-${task.id}`}
+                task={task}
+                leftPx={leftPx}
+                widthPx={widthPx}
+                topPx={rowIndex * 40 + 10}
+                isHovered={hoveredTask?.id === task.id}
+                isDragging={isDragging}
+                editMode={editMode}
+                allowProgressEdit={allowProgressEdit}
+                allowTaskResize={allowTaskResize}
+                allowTaskMove={allowTaskMove}
+                showProgress={showProgress}
+                instanceId={instanceId.current}
+                onMouseDown={handleMouseDown}
+                onMouseEnter={handleTaskMouseEnter}
+                onMouseLeave={handleTaskMouseLeave}
+                onClick={handleTaskClick}
+                renderTask={renderTask}
+                getTaskColor={getTaskColor}
+                onProgressUpdate={handleProgressUpdate}
+              />
+            );
           })}
         </React.Fragment>
       ))}
 
-      {/* Task tooltip */}
       {(hoveredTask || draggingTask) && (
         <Tooltip
           task={previewTask || draggingTask || hoveredTask!}

--- a/src/components/timeline/DependencyLinks.tsx
+++ b/src/components/timeline/DependencyLinks.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { TaskGroup, ViewMode, DependencyLink } from "@/types";
-import { TaskService } from "@/services/TaskService";
 import { CollisionService } from "@/services/CollisionService";
+import { TimeScale } from "@/core";
 
 interface TaskPosition {
   leftPx: number;
@@ -143,6 +143,9 @@ const DependencyLinks: React.FC<DependencyLinksProps> = ({
   extraLinks = [],
 }) => {
   const links = useMemo(() => {
+    // Shared coordinate system — positions match the rendered task bars exactly.
+    const scale = new TimeScale(viewMode, startDate, endDate, unitWidth);
+
     // 1. Build a position map: taskId → pixel coords
     const positions = new Map<string, TaskPosition>();
     let cumulativeY = 0;
@@ -162,13 +165,9 @@ const DependencyLinks: React.FC<DependencyLinksProps> = ({
       taskRows.forEach((rowTasks, rowIndex) => {
         rowTasks.forEach((task) => {
           try {
-            const { leftPx, widthPx } = TaskService.calculateTaskPixelPosition(
-              task,
-              startDate,
-              endDate,
-              totalUnits,
-              unitWidth,
-              viewMode,
+            const { leftPx, widthPx } = scale.positionTask(
+              task.startDate,
+              task.endDate,
             );
             const topPx = rowIndex * 40 + 10;
             const centerY = cumulativeY + topPx + 16; // half of 32px task height

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ViewMode, TooltipRenderProps } from "@/types";
-import { TaskService } from "@/services";
 import { TooltipProps } from "@/types";
 import { format } from "date-fns";
 import { getDuration } from "@/utils/dateUtils";
@@ -27,32 +26,10 @@ const Tooltip: React.FC<
   viewMode = ViewMode.MONTH,
   renderTooltip,
 }) => {
-  // Default values
-  let displayStartDate = task.startDate;
-  let displayEndDate = task.endDate;
-
-  try {
-    // If the task is being dragged/resized, get the live dates from element position
-    const id = taskId || task.id;
-    const taskEl = document.querySelector(
-      `[data-task-id="${id}"][data-instance-id="${instanceId}"]`,
-    ) as HTMLElement;
-
-    if (taskEl && (dragType || taskEl.style.left || taskEl.style.width)) {
-      const dates = TaskService.getLiveDatesFromElement(
-        taskEl,
-        startDate,
-        endDate,
-        totalMonths,
-        monthWidth,
-        viewMode,
-      );
-      displayStartDate = dates.startDate;
-      displayEndDate = dates.endDate;
-    }
-  } catch (error) {
-    console.error("Error calculating live dates for tooltip:", error);
-  }
+  // The task passed in already carries live (preview) dates during a drag, so
+  // we read them directly — no fragile DOM querying needed.
+  const displayStartDate = task.startDate;
+  const displayEndDate = task.endDate;
 
   // Calculate duration based on view mode
   const duration = getDuration(displayStartDate, displayEndDate, viewMode);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,11 @@
+export {
+  TimeScale,
+  buildTimeUnits,
+  addUnits,
+  shiftByUnits,
+  snapStart,
+  snapEnd,
+  unitMs,
+  getExtensionAmount,
+  defaultUnitWidth,
+} from "./timeScale";

--- a/src/core/timeScale.ts
+++ b/src/core/timeScale.ts
@@ -1,0 +1,431 @@
+import { ViewMode } from "@/types";
+import {
+  addMinutes,
+  addHours,
+  addDays,
+  addQuarters,
+  addYears,
+  startOfQuarter,
+  startOfYear,
+} from "date-fns";
+
+/**
+ * TimeScale — the single source of truth for mapping between dates and pixels.
+ *
+ * The whole Gantt grid is laid out as a row of fixed-width columns (one per
+ * time unit, each `unitWidth` px). A date is positioned by finding the column
+ * it falls in and interpolating *within* that column by the fraction of the
+ * column's real duration that has elapsed. Because the header renders the exact
+ * same columns at the exact same widths, bars and header always line up — there
+ * is no drift between months of different lengths, leap years, etc.
+ *
+ * `dateToX` and `xToDate` are exact inverses (modulo clamping at the edges), so
+ * dragging a task and reading its new dates back is perfectly stable: a task can
+ * never silently gain or lose duration through a move.
+ */
+export class TimeScale {
+  readonly viewMode: ViewMode;
+  readonly unitWidth: number;
+  readonly minuteStep: number;
+  /** Column start dates — one per visible time unit. */
+  readonly units: Date[];
+  /** Cached unit start times in ms for fast lookup. */
+  private readonly unitTimes: number[];
+  readonly totalWidth: number;
+
+  constructor(
+    viewMode: ViewMode,
+    startDate: Date,
+    endDate: Date,
+    unitWidth: number,
+    minuteStep = 5,
+    precomputedUnits?: Date[],
+  ) {
+    this.viewMode = viewMode;
+    this.unitWidth = unitWidth;
+    this.minuteStep = minuteStep;
+    this.units =
+      precomputedUnits ??
+      buildTimeUnits(viewMode, startDate, endDate, minuteStep);
+    this.unitTimes = this.units.map((d) => d.getTime());
+    this.totalWidth = this.units.length * unitWidth;
+  }
+
+  /** Real duration (ms) of column `i`, derived from neighbouring boundaries. */
+  private columnDurationMs(i: number): number {
+    const n = this.units.length;
+    if (n === 0) return 0;
+    if (i < n - 1) return this.unitTimes[i + 1] - this.unitTimes[i];
+    // Last column: fall back to the nominal unit length.
+    return (
+      addUnits(this.units[i], this.viewMode, 1, this.minuteStep).getTime() -
+      this.unitTimes[i]
+    );
+  }
+
+  /** Find the column index whose span contains time `t` (clamped to range). */
+  private columnIndexAt(t: number): number {
+    const n = this.unitTimes.length;
+    if (n === 0) return 0;
+    if (t <= this.unitTimes[0]) return 0;
+    if (t >= this.unitTimes[n - 1]) return n - 1;
+    let lo = 0;
+    let hi = n - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (this.unitTimes[mid] <= t) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo;
+  }
+
+  /** Map a date to an x pixel offset, clamped to [0, totalWidth]. */
+  dateToX(date: Date): number {
+    const n = this.units.length;
+    if (n === 0) return 0;
+    const t = date instanceof Date ? date.getTime() : new Date(date).getTime();
+    if (isNaN(t)) return 0;
+
+    if (t <= this.unitTimes[0]) return 0;
+    const lastDur = this.columnDurationMs(n - 1);
+    const end = this.unitTimes[n - 1] + lastDur;
+    if (t >= end) return this.totalWidth;
+
+    const i = this.columnIndexAt(t);
+    const dur = this.columnDurationMs(i) || 1;
+    const frac = (t - this.unitTimes[i]) / dur;
+    return (i + frac) * this.unitWidth;
+  }
+
+  /** Inverse of {@link dateToX}: map an x pixel offset back to a date. */
+  xToDate(x: number): Date {
+    const n = this.units.length;
+    if (n === 0) return new Date();
+    const clamped = Math.max(0, Math.min(this.totalWidth, x));
+    let i = Math.floor(clamped / this.unitWidth);
+    if (i >= n) i = n - 1;
+    if (i < 0) i = 0;
+    const frac = (clamped - i * this.unitWidth) / this.unitWidth;
+    return new Date(this.unitTimes[i] + frac * this.columnDurationMs(i));
+  }
+
+  /** Pixel left/width for a task, clamped to the visible range. */
+  positionTask(
+    taskStart: Date,
+    taskEnd: Date,
+    minWidth = 20,
+  ): { leftPx: number; widthPx: number } {
+    const leftPx = this.dateToX(taskStart);
+    const rightPx = this.dateToX(taskEnd);
+    let widthPx = Math.max(minWidth, rightPx - leftPx);
+    widthPx = Math.min(widthPx, Math.max(minWidth, this.totalWidth - leftPx));
+    return { leftPx, widthPx };
+  }
+
+  /** Index of the column containing `date`, or -1 if outside the range. */
+  currentUnitIndex(date: Date = new Date()): number {
+    const n = this.units.length;
+    if (n === 0) return -1;
+    const t = date.getTime();
+    const lastDur = this.columnDurationMs(n - 1);
+    if (t < this.unitTimes[0] || t >= this.unitTimes[n - 1] + lastDur) {
+      return -1;
+    }
+    return this.columnIndexAt(t);
+  }
+}
+
+// ── Unit grid snapping (works in date-space, independent of pixels) ──────────
+// MONTH / QUARTER / YEAR views snap to day precision, matching the historical
+// behaviour where coarse views stored clean whole-day task ranges.
+
+/** Smallest editable unit (ms) for a view mode. */
+export function unitMs(viewMode: ViewMode, minuteStep = 5): number {
+  const minute = 60 * 1000;
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return minuteStep * minute;
+    case ViewMode.HOUR:
+      return 60 * minute;
+    case ViewMode.WEEK:
+      return 7 * 24 * 60 * minute;
+    case ViewMode.DAY:
+    case ViewMode.MONTH:
+    case ViewMode.QUARTER:
+    case ViewMode.YEAR:
+    default:
+      return 24 * 60 * minute;
+  }
+}
+
+/** Snap a date down to the start of its editing unit. */
+export function snapStart(
+  date: Date,
+  viewMode: ViewMode,
+  minuteStep = 5,
+): Date {
+  const d = new Date(date);
+  switch (viewMode) {
+    case ViewMode.MINUTE: {
+      const m = Math.floor(d.getMinutes() / minuteStep) * minuteStep;
+      d.setMinutes(m, 0, 0);
+      return d;
+    }
+    case ViewMode.HOUR:
+      d.setMinutes(0, 0, 0);
+      return d;
+    default:
+      d.setHours(0, 0, 0, 0);
+      return d;
+  }
+}
+
+/** Snap a date up to the inclusive end of its editing unit. */
+export function snapEnd(date: Date, viewMode: ViewMode, minuteStep = 5): Date {
+  const d = new Date(date);
+  switch (viewMode) {
+    case ViewMode.MINUTE: {
+      const m = Math.floor(d.getMinutes() / minuteStep) * minuteStep;
+      d.setMinutes(m + minuteStep - 1, 59, 999);
+      return d;
+    }
+    case ViewMode.HOUR:
+      d.setMinutes(59, 59, 999);
+      return d;
+    default:
+      d.setHours(23, 59, 59, 999);
+      return d;
+  }
+}
+
+/** Shift a date by a whole number of editing units (used for moves). */
+export function shiftByUnits(
+  date: Date,
+  viewMode: ViewMode,
+  amount: number,
+  minuteStep = 5,
+): Date {
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return addMinutes(date, amount * minuteStep);
+    case ViewMode.HOUR:
+      return addHours(date, amount);
+    case ViewMode.WEEK:
+      return addDays(date, amount * 7);
+    case ViewMode.DAY:
+    case ViewMode.MONTH:
+    case ViewMode.QUARTER:
+    case ViewMode.YEAR:
+    default:
+      return addDays(date, amount);
+  }
+}
+
+// ── Timeline construction & extension ────────────────────────────────────────
+
+/** How many units to grow the timeline by when infinite-scroll extends it. */
+export function getExtensionAmount(viewMode: ViewMode): number {
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return 60;
+    case ViewMode.HOUR:
+      return 24;
+    case ViewMode.DAY:
+      return 7;
+    case ViewMode.WEEK:
+      return 4;
+    case ViewMode.MONTH:
+      return 3;
+    case ViewMode.QUARTER:
+      return 4;
+    case ViewMode.YEAR:
+      return 5;
+    default:
+      return 3;
+  }
+}
+
+/** Add `amount` units of `viewMode` to a date. */
+export function addUnits(
+  date: Date,
+  viewMode: ViewMode,
+  amount: number,
+  minuteStep = 5,
+): Date {
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return addMinutes(date, amount * minuteStep);
+    case ViewMode.HOUR:
+      return addHours(date, amount);
+    case ViewMode.DAY:
+      return addDays(date, amount);
+    case ViewMode.WEEK:
+      return addDays(date, amount * 7);
+    case ViewMode.MONTH:
+      return new Date(
+        date.getFullYear(),
+        date.getMonth() + amount,
+        date.getDate(),
+      );
+    case ViewMode.QUARTER:
+      return addQuarters(date, amount);
+    case ViewMode.YEAR:
+      return addYears(date, amount);
+    default:
+      return date;
+  }
+}
+
+/** Default pixel width per unit for a view mode. */
+export function defaultUnitWidth(viewMode: ViewMode): number {
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return 60;
+    case ViewMode.HOUR:
+      return 80;
+    case ViewMode.DAY:
+      return 50;
+    case ViewMode.WEEK:
+      return 80;
+    case ViewMode.MONTH:
+      return 150;
+    case ViewMode.QUARTER:
+      return 180;
+    case ViewMode.YEAR:
+      return 200;
+    default:
+      return 150;
+  }
+}
+
+/**
+ * Build the ordered list of column-start dates for a view mode. Mirrors the
+ * historical timeline generation so headers and "today" highlighting are
+ * unchanged, but lives in one place now.
+ */
+export function buildTimeUnits(
+  viewMode: ViewMode,
+  start: Date,
+  end: Date,
+  minuteStep = 5,
+): Date[] {
+  if (
+    !(start instanceof Date) ||
+    !(end instanceof Date) ||
+    isNaN(start.getTime()) ||
+    isNaN(end.getTime())
+  ) {
+    return [];
+  }
+
+  switch (viewMode) {
+    case ViewMode.MINUTE:
+      return buildMinutes(start, end, minuteStep);
+    case ViewMode.HOUR:
+      return buildHours(start, end);
+    case ViewMode.DAY:
+      return buildDays(start, end);
+    case ViewMode.WEEK:
+      return buildWeeks(start, end);
+    case ViewMode.MONTH:
+      return buildMonths(start, end);
+    case ViewMode.QUARTER:
+      return buildQuarters(start, end);
+    case ViewMode.YEAR:
+      return buildYears(start, end);
+    default:
+      return buildMonths(start, end);
+  }
+}
+
+function buildMinutes(start: Date, end: Date, step: number): Date[] {
+  const out: Date[] = [];
+  const cur = new Date(start);
+  cur.setSeconds(0, 0);
+  cur.setMinutes(Math.floor(cur.getMinutes() / step) * step);
+
+  const endAdj = new Date(end);
+  endAdj.setSeconds(59, 999);
+
+  // Cap at 500 intervals to keep the minute view responsive.
+  const maxIntervals = 500;
+  let count = 0;
+  while (cur <= endAdj && count < maxIntervals) {
+    out.push(new Date(cur));
+    cur.setMinutes(cur.getMinutes() + step);
+    count++;
+  }
+  return out;
+}
+
+function buildHours(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const cur = new Date(start);
+  cur.setMinutes(0, 0, 0);
+  const endAdj = new Date(end);
+  endAdj.setMinutes(59, 59, 999);
+  while (cur <= endAdj) {
+    out.push(new Date(cur));
+    cur.setHours(cur.getHours() + 1);
+  }
+  return out;
+}
+
+function buildDays(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const cur = new Date(start);
+  cur.setHours(0, 0, 0, 0);
+  const endAdj = new Date(end);
+  endAdj.setHours(23, 59, 59, 999);
+  while (cur <= endAdj) {
+    out.push(new Date(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return out;
+}
+
+function buildWeeks(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const cur = new Date(start);
+  while (cur <= end) {
+    out.push(new Date(cur));
+    cur.setDate(cur.getDate() + 7);
+  }
+  return out;
+}
+
+function buildMonths(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const startYear = start.getFullYear();
+  const startMonth = start.getMonth();
+  const endYear = end.getFullYear();
+  const endMonth = end.getMonth();
+  for (let y = startYear; y <= endYear; y++) {
+    const mStart = y === startYear ? startMonth : 0;
+    const mEnd = y === endYear ? endMonth : 11;
+    for (let m = mStart; m <= mEnd; m++) {
+      out.push(new Date(y, m, 1));
+    }
+  }
+  return out;
+}
+
+function buildQuarters(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const cur = startOfQuarter(new Date(start));
+  while (cur <= end) {
+    out.push(new Date(cur));
+    cur.setMonth(cur.getMonth() + 3);
+  }
+  return out;
+}
+
+function buildYears(start: Date, end: Date): Date[] {
+  const out: Date[] = [];
+  const cur = startOfYear(new Date(start));
+  while (cur <= end) {
+    out.push(new Date(cur));
+    cur.setFullYear(cur.getFullYear() + 1);
+  }
+  return out;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,5 +89,18 @@ export {
   detectTaskOverlaps,
 } from "./utils";
 
+// Core coordinate system (advanced usage)
+export {
+  TimeScale,
+  buildTimeUnits,
+  addUnits,
+  shiftByUnits,
+  snapStart,
+  snapEnd,
+  unitMs,
+  getExtensionAmount,
+  defaultUnitWidth,
+} from "./core";
+
 // Export themes
 export { defaultTheme, darkTheme } from "./themes";

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -1,9 +1,14 @@
 import { Task, ViewMode } from "@/types";
-import { startOfDay, endOfDay, isWithinInterval } from "date-fns";
+import { isWithinInterval } from "date-fns";
+import { TimeScale, snapStart, snapEnd } from "@/core";
 
 export class TaskService {
   /**
-   * Calculate the new dates for a task based on pixel position
+   * Calculate the new dates for a task based on pixel position.
+   *
+   * Delegates to {@link TimeScale} so the inverse mapping is consistent with
+   * how tasks are positioned — a drag round-trip can never change a task's
+   * duration through accumulated rounding error.
    */
   public static calculateDatesFromPosition(
     left: number,
@@ -15,99 +20,8 @@ export class TaskService {
     viewMode: ViewMode = ViewMode.MONTH,
   ): { newStartDate: Date; newEndDate: Date } {
     try {
-      // Make sure we're working with valid numbers
-      const safeLeft = isNaN(left) ? 0 : left;
-      const safeWidth = isNaN(width) || width < 20 ? 20 : width;
-
-      // Calculate the time range of the entire timeline
-      const timelineStartTime = startDate.getTime();
-      const timelineEndTime = endDate.getTime();
-      const timelineDuration = timelineEndTime - timelineStartTime;
-
-      // Calculate milliseconds per pixel
-      const msPerPixel = timelineDuration / (totalUnits * unitWidth);
-
-      // Convert pixel position to time offsets
-      const startOffset = safeLeft * msPerPixel;
-      const durationMs = safeWidth * msPerPixel;
-
-      // Create new Date objects from the calculated times
-      let newStartDate = new Date(timelineStartTime + startOffset);
-      let newEndDate = new Date(timelineStartTime + startOffset + durationMs);
-
-      // Special handling for different view modes
-      switch (viewMode) {
-        case ViewMode.MINUTE:
-          // Snap to minute boundaries like day view
-          const minutesFromStart = Math.round(left / unitWidth);
-          const minuteSpan = Math.max(1, Math.round(width / unitWidth));
-
-          const baseMinute = new Date(startDate);
-          baseMinute.setSeconds(0, 0);
-
-          newStartDate = new Date(baseMinute);
-          newStartDate.setMinutes(baseMinute.getMinutes() + minutesFromStart);
-          newStartDate.setSeconds(0, 0);
-
-          newEndDate = new Date(newStartDate);
-          newEndDate.setMinutes(newStartDate.getMinutes() + minuteSpan - 1);
-          newEndDate.setSeconds(59, 999);
-          break;
-
-        case ViewMode.HOUR:
-          // Snap to hour boundaries like day view
-          const hoursFromStart = Math.round(left / unitWidth);
-          const hourSpan = Math.max(1, Math.round(width / unitWidth));
-
-          const baseHour = new Date(startDate);
-          baseHour.setMinutes(0, 0, 0);
-
-          newStartDate = new Date(baseHour);
-          newStartDate.setHours(baseHour.getHours() + hoursFromStart);
-          newStartDate.setMinutes(0, 0, 0);
-
-          newEndDate = new Date(newStartDate);
-          newEndDate.setHours(newStartDate.getHours() + hourSpan - 1);
-          newEndDate.setMinutes(59, 59, 999);
-          break;
-
-        case ViewMode.DAY:
-          // Calculate how many units (days) from the start
-          const daysFromStart = Math.round(left / unitWidth);
-
-          // Calculate how many days the task spans
-          const daySpan = Math.max(1, Math.round(width / unitWidth));
-
-          // Create new dates based on exact day offsets from the start date
-          const baseDate = new Date(startDate);
-          baseDate.setHours(0, 0, 0, 0);
-
-          // Apply precise day calculations to avoid any off-by-one errors
-          newStartDate = new Date(baseDate);
-          newStartDate.setDate(baseDate.getDate() + daysFromStart);
-          newStartDate.setHours(0, 0, 0, 0);
-
-          newEndDate = new Date(newStartDate);
-          newEndDate.setDate(newStartDate.getDate() + daySpan - 1);
-          newEndDate.setHours(23, 59, 59, 999);
-          break;
-
-        default:
-          newStartDate = startOfDay(newStartDate);
-          newEndDate = endOfDay(newEndDate);
-          break;
-      }
-
-      // Ensure dates don't extend beyond the timeline boundaries
-      if (newStartDate < startDate) {
-        newStartDate = new Date(startDate);
-      }
-
-      if (newEndDate > endDate) {
-        newEndDate = new Date(endDate);
-      }
-
-      return { newStartDate, newEndDate };
+      const scale = new TimeScale(viewMode, startDate, endDate, unitWidth);
+      return this.datesFromPositionWithScale(scale, left, width, viewMode);
     } catch (error) {
       console.error("Error calculating dates from position:", error);
       return {
@@ -117,9 +31,29 @@ export class TaskService {
     }
   }
 
-  /**
-   * Create an updated task with new dates
-   */
+  /** Scale-based variant of {@link calculateDatesFromPosition}. */
+  public static datesFromPositionWithScale(
+    scale: TimeScale,
+    left: number,
+    width: number,
+    viewMode: ViewMode = ViewMode.MONTH,
+    minuteStep = 5,
+  ): { newStartDate: Date; newEndDate: Date } {
+    const safeLeft = isNaN(left) ? 0 : left;
+    const safeWidth = isNaN(width) || width < 1 ? scale.unitWidth : width;
+
+    const rawStart = scale.xToDate(safeLeft);
+    // The right edge is exclusive: a bar ending exactly on a column boundary
+    // belongs to the column on its left, so nudge inward before snapping.
+    const rawEnd = scale.xToDate(safeLeft + safeWidth - 0.001);
+
+    const newStartDate = snapStart(rawStart, viewMode, minuteStep);
+    const newEndDate = snapEnd(rawEnd, viewMode, minuteStep);
+
+    return { newStartDate, newEndDate };
+  }
+
+  /** Create an updated task with new dates. */
   public static createUpdatedTask(
     task: Task,
     newStartDate: Date,
@@ -133,7 +67,11 @@ export class TaskService {
   }
 
   /**
-   * Calculates position and width for a task in pixels
+   * Calculates position and width for a task in pixels.
+   *
+   * Builds a {@link TimeScale} internally for backward compatibility. When
+   * rendering many tasks, prefer {@link positionTaskWithScale} with a shared
+   * scale to avoid rebuilding the column grid per task.
    */
   public static calculateTaskPixelPosition(
     task: Task,
@@ -150,173 +88,33 @@ export class TaskService {
       ) {
         throw new Error("Invalid dates in task");
       }
-
-      // Normalize dates based on view mode for consistent calculations
-      let timelineStartTime = startDate.getTime();
-      let timelineEndTime = endDate.getTime();
-      let taskStartTime = Math.max(
-        task.startDate.getTime(),
-        startDate.getTime(),
-      );
-      let taskEndTime = Math.min(task.endDate.getTime(), endDate.getTime());
-
-      // Apply special handling for view modes
-      if (
-        viewMode === ViewMode.MINUTE ||
-        viewMode === ViewMode.HOUR ||
-        viewMode === ViewMode.DAY
-      ) {
-        // Ensure consistent boundaries using appropriate precision
-        let startPrecision, endPrecision;
-
-        if (viewMode === ViewMode.MINUTE) {
-          // No special rounding for minute view
-          startPrecision = timelineStartTime;
-          endPrecision = timelineEndTime;
-        } else if (viewMode === ViewMode.HOUR) {
-          // Round to hours
-          const startHourTime = new Date(
-            startDate.getFullYear(),
-            startDate.getMonth(),
-            startDate.getDate(),
-            startDate.getHours(),
-            0,
-            0,
-            0,
-          ).getTime();
-
-          const endHourTime = new Date(
-            endDate.getFullYear(),
-            endDate.getMonth(),
-            endDate.getDate(),
-            endDate.getHours(),
-            59,
-            59,
-            999,
-          ).getTime();
-
-          startPrecision = startHourTime;
-          endPrecision = endHourTime;
-        } else {
-          // Round to days for day view
-          const startOfDayTime = new Date(
-            startDate.getFullYear(),
-            startDate.getMonth(),
-            startDate.getDate(),
-            0,
-            0,
-            0,
-            0,
-          ).getTime();
-
-          const endOfDayTime = new Date(
-            endDate.getFullYear(),
-            endDate.getMonth(),
-            endDate.getDate(),
-            23,
-            59,
-            59,
-            999,
-          ).getTime();
-
-          startPrecision = startOfDayTime;
-          endPrecision = endOfDayTime;
-        }
-
-        timelineStartTime = startPrecision;
-        timelineEndTime = endPrecision;
-
-        // Also normalize task times to the appropriate precision
-        if (viewMode === ViewMode.DAY) {
-          const taskStartDay = new Date(
-            new Date(taskStartTime).getFullYear(),
-            new Date(taskStartTime).getMonth(),
-            new Date(taskStartTime).getDate(),
-            0,
-            0,
-            0,
-            0,
-          ).getTime();
-
-          const taskEndDay = new Date(
-            new Date(taskEndTime).getFullYear(),
-            new Date(taskEndTime).getMonth(),
-            new Date(taskEndTime).getDate(),
-            23,
-            59,
-            59,
-            999,
-          ).getTime();
-
-          taskStartTime = taskStartDay;
-          taskEndTime = taskEndDay;
-        }
-      }
-
-      // Calculate the full timeline range
-      const totalTimelineRange = timelineEndTime - timelineStartTime;
-
-      // Convert time differences to pixel positions
-      const distanceFromStart = taskStartTime - timelineStartTime;
-      const taskDuration = taskEndTime - taskStartTime;
-
-      // Calculate percentages of total timeline
-      const leftPercent = distanceFromStart / totalTimelineRange;
-      const widthPercent = taskDuration / totalTimelineRange;
-
-      // Calculate pixel positions
-      const totalPixelWidth = totalUnits * unitWidth;
-      let leftPx = leftPercent * totalPixelWidth;
-      let widthPx = widthPercent * totalPixelWidth;
-
-      // Add view mode specific adjustments for alignment
-      if (viewMode === ViewMode.MINUTE) {
-        // Fine adjustments for minute view
-        leftPx = Math.round(leftPx);
-        widthPx = Math.max(10, Math.round(widthPx));
-      } else if (viewMode === ViewMode.HOUR) {
-        // Round to hour boundaries for cleaner display
-        leftPx = Math.round(leftPx);
-        widthPx = Math.max(15, Math.round(widthPx));
-      } else if (viewMode === ViewMode.DAY) {
-        // Snap to day boundaries
-        leftPx = Math.round(leftPx / unitWidth) * unitWidth;
-        widthPx = Math.max(
-          unitWidth,
-          Math.round(widthPx / unitWidth) * unitWidth,
-        );
-      }
-
-      // Apply view mode specific adjustments for minimum width
-      const minWidthByViewMode = {
-        [ViewMode.MINUTE]: 10, // Narrower for minute view
-        [ViewMode.HOUR]: 15, // Narrow for hour view
-        [ViewMode.DAY]: 20,
-        [ViewMode.WEEK]: 20,
-        [ViewMode.MONTH]: 20,
-        [ViewMode.QUARTER]: 30,
-        [ViewMode.YEAR]: 40,
-      };
-
-      // Ensure minimum width
-      const minWidth = minWidthByViewMode[viewMode] || 20;
-      widthPx = Math.max(minWidth, widthPx);
-
-      // Ensure not extending beyond timeline
-      const maxWidth = totalPixelWidth - leftPx;
-      widthPx = Math.min(maxWidth, widthPx);
-
-      return { leftPx, widthPx };
+      const scale = new TimeScale(viewMode, startDate, endDate, unitWidth);
+      return this.positionTaskWithScale(scale, task);
     } catch (error) {
       console.error("Error calculating task position:", error);
-      // Return a default position as fallback
       return { leftPx: 0, widthPx: 20 };
     }
   }
 
-  /**
-   * Get live dates from element position during drag
-   */
+  /** Scale-based variant of {@link calculateTaskPixelPosition}. */
+  public static positionTaskWithScale(
+    scale: TimeScale,
+    task: Task,
+  ): { leftPx: number; widthPx: number } {
+    const minWidthByViewMode: Record<string, number> = {
+      [ViewMode.MINUTE]: 10,
+      [ViewMode.HOUR]: 15,
+      [ViewMode.DAY]: 20,
+      [ViewMode.WEEK]: 20,
+      [ViewMode.MONTH]: 20,
+      [ViewMode.QUARTER]: 30,
+      [ViewMode.YEAR]: 40,
+    };
+    const minWidth = minWidthByViewMode[scale.viewMode] || 20;
+    return scale.positionTask(task.startDate, task.endDate, minWidth);
+  }
+
+  /** Get live dates from element position during drag. */
   public static getLiveDatesFromElement(
     taskEl: HTMLElement | null,
     startDate: Date,
@@ -329,10 +127,8 @@ export class TaskService {
       if (!taskEl) {
         return { startDate: new Date(startDate), endDate: new Date(endDate) };
       }
-
       const left = parseFloat(taskEl.style.left || "0");
       const width = parseFloat(taskEl.style.width || "0");
-
       const { newStartDate, newEndDate } = this.calculateDatesFromPosition(
         left,
         width,
@@ -342,7 +138,6 @@ export class TaskService {
         unitWidth,
         viewMode,
       );
-
       return { startDate: newStartDate, endDate: newEndDate };
     } catch (error) {
       console.error("Error getting live dates:", error);
@@ -350,9 +145,7 @@ export class TaskService {
     }
   }
 
-  /**
-   * Check if two date ranges overlap
-   */
+  /** Check if two date ranges overlap. */
   public static datesOverlap(
     startA: Date,
     endA: Date,

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -165,6 +165,7 @@ export interface TaskRowProps {
   onTaskSelect?: (task: Task, isSelected: boolean) => void;
   onAutoScrollChange?: (isScrolling: boolean) => void;
   viewMode?: ViewMode;
+  minuteStep?: number;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 
   // NEW: Infinite scroll support

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": null,
+    "declaration": false,
+    "declarationDir": null,
+    "declarationMap": false,
+    "composite": false,
+    "isolatedModules": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "sourceMap": true,
         "outDir": "dist",
         "baseUrl": ".",
+        "ignoreDeprecations": "6.0",
         "paths": {
             "@/*": ["src/*"]
         }


### PR DESCRIPTION
## Why

The chart had **three inconsistent ways** of mapping dates to pixels:

1. the header laid out **equal-width columns** (every month 150px, etc.),
2. task bars used **linear millisecond interpolation** over the whole range, and
3. `positionUtils.calculateTaskPosition` was a third, month-index/percent algorithm (exported but unused in rendering).

Because months/quarters/years have different real lengths, the bars drifted away from their header columns — and the drift changed per view mode. That is exactly the "positioning isn't accurate, especially when the view changes at the top" symptom. On top of that, drag was a ~960-line tangle of DOM mutation + React state + refs + a manual easing engine, with **separate code paths** for day vs other views whose forward/inverse math wasn't symmetric (a move could silently change a task's duration). Infinite-scroll-while-dragging could stretch a task to an absurd width.

## What changed

A single, invertible **`TimeScale`** is now the source of truth. The grid is modelled as fixed-width columns; a date is placed by interpolating *within its real column duration*. The header, bars, today marker and dependency arrows all derive from it, so they line up exactly in every view mode — no drift. `dateToX`/`xToDate` are exact inverses, so drag round-trips are stable.

- **`src/core/timeScale.ts`** — `TimeScale` (`dateToX`/`xToDate`/`positionTask`/`currentUnitIndex`), unit-grid snapping (`snapStart`/`snapEnd`), `shiftByUnits` for moves, and timeline build/extension helpers (consolidating the old `get*Between`/`add*`/`subtract*` functions).
- **`TaskRow`** — drag fully reworked in **date-space**, one path for all view modes. The grab anchor is kept in date/grid coordinates and the latest scale is read via a ref, so extending the timeline mid-drag re-derives positions from the unchanged dates instead of corrupting pixel state (**fixes the infinite-scroll "task grows infinitely" bug**). Removes the manual animation engine, the `document.querySelector` drag lookups, and the `forceRender` full-remount-per-update hack.
- **`TaskService`** — position/date math delegates to `TimeScale`; the right edge is treated as exclusive so a bar ending on a column boundary stays in the left column. **Public signatures preserved.**
- **`GanttChart`** — shares one scale, memoizes the today-marker height, routes scroll/extension through the core helpers.
- **`DependencyLinks` / `Tooltip`** — reuse the shared scale and the live preview dates instead of recomputing positions / reading the DOM.

Net: **−1247 lines**, much simpler, and behaviour is far more accurate.

## Compatibility

Public API is unchanged (all props, exports and component signatures preserved). `TimeScale` and its helpers are additionally exported for advanced use. `TaskRowProps` gains an optional `minuteStep`.

## Tests

- New `TimeScale` suite covering drift (boundary alignment), exact invertibility, clamping, snapping and unit shifts.
- All **50** tests pass; build is green. `ts-jest` configured for TypeScript 6 (the suite previously failed to run at all due to TS6 config deprecations).

## Notes / follow-ups

- A true dependency *scheduling* model (FS/SS/FF/SF link types, lag, auto-shifting dependents, cycle detection) is the natural next step — this PR makes dependency arrows pixel-consistent but keeps them visual-only.
- One pre-existing lint error remains in `ExportPreview.tsx` (untouched here).

https://claude.ai/code/session_01Vdq1nqbhcLRGQRqd7kYHeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vdq1nqbhcLRGQRqd7kYHeQ)_